### PR TITLE
Issue #4 - swap generators at runtime

### DIFF
--- a/library/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/library/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -273,6 +273,18 @@ public class CutoutViewIndicator extends LinearLayout {
     }
 
     /**
+     * Returns a reference to the generator used to create and bind
+     * cells. Default value is an instance of {@link ImageViewGenerator}.
+     *
+     * @return the generator currently in use
+     * @see #setGenerator(LayeredViewGenerator)
+     */
+    @NonNull
+    public LayeredViewGenerator getGenerator() {
+        return generator;
+    }
+
+    /**
      * Asks the {@link #generator} to create a new cell.
      *
      * @param position used as 'index' parameter to {@link #addView(View, int)}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextViewGenerator.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextViewGenerator.java
@@ -17,8 +17,10 @@ package com.fuzz.emptyhusk;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
 
 import com.fuzz.indicator.text.MigratoryStyleSpan;
 import com.fuzz.indicator.text.TextViewGenerator;
@@ -39,9 +41,21 @@ public class BoldTextViewGenerator extends TextViewGenerator {
         SpannableString ssb = new SpannableString(introStrings[position]);
         MigratoryStyleSpan span = new MigratoryStyleSpan(BOLD);
 
+        // Order matters when setting spans. The base color must be in place first
+
+        ForegroundColorSpan colorSpan = new ForegroundColorSpan(ContextCompat.getColor(context, R.color.colorSecondary));
+        ssb.setSpan(colorSpan, 0, ssb.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+
+        // Only then should custom MigratorySpans be set.
+
         int end = (int) (ssb.length() * span.getCoverage().diff());
         ssb.setSpan(span, 0, end, span.preferredFlags(0));
 
+
+        MigratoryForegroundColorSpan boldColorSpan = new MigratoryForegroundColorSpan(ContextCompat.getColor(context, R.color.colorAccent));
+        ssb.setSpan(boldColorSpan, 0, end, boldColorSpan.preferredFlags(0));
+
         return ssb;
     }
+
 }

--- a/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextViewGenerator.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextViewGenerator.java
@@ -30,7 +30,7 @@ import static android.graphics.Typeface.BOLD;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-class BoldTextViewGenerator extends TextViewGenerator {
+public class BoldTextViewGenerator extends TextViewGenerator {
     @NonNull
     @Override
     protected Spannable getTextFor(@NonNull Context context, int position) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/BoundValueListener.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/BoundValueListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk;
+
+import android.content.Context;
+import android.widget.NumberPicker;
+
+/**
+ * Custom {@code OnValueChangeListener} which treats values passed into
+ * {@link #onValueChange(NumberPicker, int, int)} as quantities of
+ * device-independent pixels (a.k.a dp).
+ * <p>
+ *     A converted, device-dependent quantity of pixels is passed into
+ *     {@link #onNewValue(int)}.
+ * </p>
+ * @see #derivePXFrom(Context, int)
+ * @see #deriveDPFrom(Context, int)
+ */
+abstract class BoundValueListener implements NumberPicker.OnValueChangeListener {
+
+    @Override
+    public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
+        if (newVal >= 0) {
+            int px = MainActivity.derivePXFrom(picker.getContext(), newVal);
+            onNewValue(px);
+        }
+    }
+
+    /**
+     * @param px    a chosen number of pixels, 0 or greater
+     */
+    protected abstract void onNewValue(int px);
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
@@ -21,10 +21,15 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 
+import com.fuzz.emptyhusk.choosegenerator.GeneratorChoiceFragment;
+import com.fuzz.emptyhusk.choosegenerator.OnSelectedListener;
 import com.fuzz.indicator.CutoutViewIndicator;
+import com.fuzz.indicator.LayeredViewGenerator;
 
 /**
  * Entry point into the sample application. This is designed to cover all the basic
@@ -47,6 +52,20 @@ public class MainActivity extends AppCompatActivity {
     protected MainViewBinding binding;
 
     protected PickerDelegate pickerDelegate;
+
+    protected OnSelectedListener<Class<? extends LayeredViewGenerator>> onGeneratorSelectedListener
+            = new OnSelectedListener<Class<? extends LayeredViewGenerator>>() {
+        @Override
+        public void onSelected(@NonNull Class<? extends LayeredViewGenerator> chosen) {
+            try {
+                binding.cvi.setGenerator(chosen.newInstance());
+            } catch (Exception e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -72,6 +91,31 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.main_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        boolean consumed = false;
+        switch (item.getItemId()) {
+            case R.id.changeGenerator:
+                GeneratorChoiceFragment fragment = GeneratorChoiceFragment.newInstance(binding.cvi.getGenerator().getClass());
+                fragment.setOnSelectedListener(onGeneratorSelectedListener);
+                getFragmentManager()
+                        .beginTransaction()
+                        .add(fragment, GeneratorChoiceFragment.TAG)
+                        .addToBackStack(GeneratorChoiceFragment.TAG)
+                        .commit();
+                consumed = true;
+                break;
+        }
+
+        return consumed && super.onOptionsItemSelected(item);
+    }
 
     private void initButtons() {
         binding.unifiedButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
@@ -19,14 +19,10 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.design.widget.FloatingActionButton;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.CompoundButton;
-import android.widget.NumberPicker;
-import android.widget.NumberPicker.OnValueChangeListener;
 
 import com.fuzz.indicator.CutoutViewIndicator;
 
@@ -36,85 +32,62 @@ import com.fuzz.indicator.CutoutViewIndicator;
  */
 public class MainActivity extends AppCompatActivity {
 
-    private static int deriveDPFrom(Context context, int pixelCount) {
+    public static int deriveDPFrom(Context context, int pixelCount) {
         float retVal = pixelCount / context.getResources().getDisplayMetrics().density;
 
         return ((int) retVal);
     }
 
-    private static int derivePXFrom(Context context, int dpCount) {
+    public static int derivePXFrom(Context context, int dpCount) {
         float retVal = dpCount * context.getResources().getDisplayMetrics().density;
 
         return ((int) retVal);
     }
 
+    protected MainViewBinding binding;
+
+    protected PickerDelegate pickerDelegate;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
 
-        ViewPager viewPager = (ViewPager) findViewById(R.id.mainViewPager);
+        binding = new MainViewBinding(findViewById(R.id.root));
+        pickerDelegate = new PickerDelegate(binding);
+
+        setSupportActionBar(binding.toolbar);
+
         SimplePagerAdapter adapter = defineAdapter(getResources());
-        initPager(viewPager, adapter);
+        initPager(binding.mainViewPager, adapter);
 
-        CutoutViewIndicator cvi = (CutoutViewIndicator) findViewById(R.id.cutoutViewIndicator);
-        initIndicator(cvi, viewPager);
+        initIndicator(binding.cvi, binding.mainViewPager);
 
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
-        CompoundButton unifiedButton = (CompoundButton) findViewById(R.id.unifiedSwitch);
-        CompoundButton orientationButton = (CompoundButton) findViewById(R.id.orientationSwitch);
-        View gridLayout = findViewById(R.id.gridLayout);
-        initButtons(fab, unifiedButton, orientationButton, gridLayout, cvi);
+        initButtons();
 
-        NumberPicker spacing = (NumberPicker) findViewById(R.id.spacingPicker);
-        NumberPicker width = (NumberPicker) findViewById(R.id.widthPicker);
-        NumberPicker height = (NumberPicker) findViewById(R.id.heightPicker);
-        initPickers(spacing, width, height, cvi);
+        pickerDelegate.initPickers();
 
-        if (viewPager != null) {
-            viewPager.setCurrentItem(1);
+        if (binding.mainViewPager != null) {
+            binding.mainViewPager.setCurrentItem(1);
         }
     }
 
-    private void initButtons(
-            FloatingActionButton fab,
-            CompoundButton unified,
-            CompoundButton orientationButton,
-            final View anchor,
-            final CutoutViewIndicator cvi
-    ) {
-        unified.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+
+    private void initButtons() {
+        binding.unifiedButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton view, boolean isChecked) {
-                cvi.cascadeParamChanges(isChecked);
+                binding.cvi.cascadeParamChanges(isChecked);
             }
         });
-        orientationButton.setOnCheckedChangeListener(new ToggleAlignmentListener(cvi, anchor));
-        fab.setOnClickListener(new SwitchIndicatorsListener(cvi) {
+        binding.orientationButton.setOnCheckedChangeListener(new ToggleAlignmentListener(binding.cvi, binding.gridLayout));
+        binding.fab.setOnClickListener(new SwitchIndicatorsListener(binding.cvi) {
             @Override
             public void onClick(View v) {
                 super.onClick(v);
-                setPickerValuesFrom(cvi);
+                pickerDelegate.setPickerValuesFrom(binding.cvi);
             }
         });
-    }
-
-    private void setPickerValuesFrom(@NonNull CutoutViewIndicator cvi) {
-        NumberPicker spacing = (NumberPicker) findViewById(R.id.spacingPicker);
-        NumberPicker width = (NumberPicker) findViewById(R.id.widthPicker);
-        NumberPicker height = (NumberPicker) findViewById(R.id.heightPicker);
-
-        if (spacing != null) {
-            spacing.setValue(deriveDPFrom(this, cvi.getInternalSpacing()));
-        }
-        if (width != null) {
-            width.setValue(deriveDPFrom(this, cvi.getCellLength()));
-        }
-        if (height != null) {
-            height.setValue(deriveDPFrom(this, cvi.getPerpendicularLength()));
-        }
     }
 
     @NonNull
@@ -132,63 +105,4 @@ public class MainActivity extends AppCompatActivity {
         cvi.setViewPager(viewPager);
     }
 
-    private void initPickers(
-            NumberPicker spacing, NumberPicker width, NumberPicker height,
-            final CutoutViewIndicator cvi
-    ) {
-        setRangeOn(spacing);
-        spacing.setOnValueChangedListener(new BoundValueListener() {
-            @Override
-            protected void onNewValue(int px) {
-                cvi.setInternalSpacing(px);
-            }
-        });
-        setRangeOn(width);
-        width.setOnValueChangedListener(new BoundValueListener() {
-            @Override
-            protected void onNewValue(int px) {
-                cvi.setCellLength(px);
-            }
-        });
-        setRangeOn(height);
-        height.setOnValueChangedListener(new BoundValueListener() {
-            protected void onNewValue(int px) {
-                cvi.setPerpendicularLength(px);
-            }
-        });
-        // Initial values can only be set after the ranges have been defined
-        setPickerValuesFrom(cvi);
-    }
-
-    private void setRangeOn(NumberPicker picker) {
-        picker.setMinValue(0);
-        picker.setMaxValue(200);
-    }
-
-    /**
-     * Custom {@code OnValueChangeListener} which treats values passed into
-     * {@link #onValueChange(NumberPicker, int, int)} as quantities of
-     * device-independent pixels (a.k.a dp).
-     * <p>
-     *     A converted, device-dependent quantity of pixels is passed into
-     *     {@link #onNewValue(int)}.
-     * </p>
-     * @see #derivePXFrom(Context, int)
-     * @see #deriveDPFrom(Context, int)
-     */
-    private abstract static class BoundValueListener implements OnValueChangeListener {
-
-        @Override
-        public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
-            if (newVal >= 0) {
-                int px = derivePXFrom(picker.getContext(), newVal);
-                onNewValue(px);
-            }
-        }
-
-        /**
-         * @param px    a chosen number of pixels, 0 or greater
-         */
-        protected abstract void onNewValue(int px);
-    }
 }

--- a/mobile/src/main/java/com/fuzz/emptyhusk/MainViewBinding.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/MainViewBinding.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk;
+
+import android.support.design.widget.FloatingActionButton;
+import android.support.v4.view.ViewPager;
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+import android.widget.CompoundButton;
+import android.widget.GridLayout;
+import android.widget.NumberPicker;
+
+import com.fuzz.indicator.CutoutViewIndicator;
+
+/**
+ * Like a DataBinding-generated file, only without any observable inheritance or
+ * any Annotation processing.
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public class MainViewBinding {
+    public final Toolbar toolbar;
+    public final ViewPager mainViewPager;
+    public final FloatingActionButton fab;
+
+    public final NumberPicker spacing;
+    public final NumberPicker width;
+    public final NumberPicker height;
+    public final GridLayout gridLayout;
+
+    public final CutoutViewIndicator cvi;
+    public final CompoundButton unifiedButton;
+    public final CompoundButton orientationButton;
+
+    public MainViewBinding(View root) {
+        toolbar = (Toolbar) root.findViewById(R.id.toolbar);
+        mainViewPager = (ViewPager) root.findViewById(R.id.mainViewPager);
+        fab = (FloatingActionButton) root.findViewById(R.id.fab);
+
+        cvi = (CutoutViewIndicator) root.findViewById(R.id.cutoutViewIndicator);
+
+        spacing = (NumberPicker) root.findViewById(R.id.spacingPicker);
+        width = (NumberPicker) root.findViewById(R.id.widthPicker);
+        height = (NumberPicker) root.findViewById(R.id.heightPicker);
+
+        gridLayout = (GridLayout) root.findViewById(R.id.gridLayout);
+
+        unifiedButton = (CompoundButton) root.findViewById(R.id.unifiedSwitch);
+        orientationButton = (CompoundButton) root.findViewById(R.id.orientationSwitch);
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/MigratoryForegroundColorSpan.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/MigratoryForegroundColorSpan.java
@@ -1,0 +1,48 @@
+package com.fuzz.emptyhusk;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.text.Spannable;
+import android.text.style.ForegroundColorSpan;
+
+import com.fuzz.indicator.text.MigratoryRange;
+import com.fuzz.indicator.text.MigratorySpan;
+
+/**
+ * Migratory variant of {@link ForegroundColorSpan}.
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+class MigratoryForegroundColorSpan extends ForegroundColorSpan implements MigratorySpan, Parcelable {
+    public MigratoryForegroundColorSpan(int color) {
+        super(color);
+    }
+
+    public MigratoryForegroundColorSpan(Parcel in) {
+        super(in);
+    }
+
+    @NonNull
+    @Override
+    public MigratoryRange<Float> getCoverage() {
+        return MigratoryRange.from(.2f, .8f);
+    }
+
+    @Override
+    public int preferredFlags(int previousFlags) {
+        return Spannable.SPAN_INCLUSIVE_INCLUSIVE;
+    }
+
+    public static final Creator<MigratoryForegroundColorSpan> CREATOR = new Creator<MigratoryForegroundColorSpan>() {
+        @Override
+        public MigratoryForegroundColorSpan createFromParcel(Parcel in) {
+            return new MigratoryForegroundColorSpan(in);
+        }
+
+        @Override
+        public MigratoryForegroundColorSpan[] newArray(int size) {
+            return new MigratoryForegroundColorSpan[size];
+        }
+    };
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/PickerDelegate.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/PickerDelegate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk;
+
+import android.support.annotation.NonNull;
+import android.widget.NumberPicker;
+
+import com.fuzz.indicator.CutoutViewIndicator;
+
+import static com.fuzz.emptyhusk.MainActivity.deriveDPFrom;
+
+/**
+ * Utility class designed solely to handle state changes on the NumberPickers shown
+ * in {@link MainActivity}.
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public class PickerDelegate {
+
+    @NonNull
+    protected MainViewBinding binding;
+
+    public PickerDelegate(@NonNull MainViewBinding binding) {
+        this.binding = binding;
+    }
+
+    public void initPickers() {
+        setRangeOn(binding.spacing);
+        binding.spacing.setOnValueChangedListener(new BoundValueListener() {
+            @Override
+            protected void onNewValue(int px) {
+                binding.cvi.setInternalSpacing(px);
+            }
+        });
+        setRangeOn(binding.width);
+        binding.width.setOnValueChangedListener(new BoundValueListener() {
+            @Override
+            protected void onNewValue(int px) {
+                binding.cvi.setCellLength(px);
+            }
+        });
+        setRangeOn(binding.height);
+        binding.height.setOnValueChangedListener(new BoundValueListener() {
+            protected void onNewValue(int px) {
+                binding.cvi.setPerpendicularLength(px);
+            }
+        });
+        // Initial values can only be set after the ranges have been defined
+        setPickerValuesFrom(binding.cvi);
+    }
+
+    protected void setRangeOn(NumberPicker picker) {
+        picker.setWrapSelectorWheel(false);
+        picker.setMinValue(0);
+        picker.setMaxValue(200);
+    }
+
+    void setPickerValuesFrom(@NonNull CutoutViewIndicator cvi) {
+        NumberPicker spacing = binding.spacing;
+        NumberPicker width = binding.width;
+        NumberPicker height = binding.height;
+
+        if (spacing != null) {
+            spacing.setValue(deriveDPFrom(cvi.getContext(), cvi.getInternalSpacing()));
+        }
+        if (width != null) {
+            width.setValue(deriveDPFrom(cvi.getContext(), cvi.getCellLength()));
+        }
+        if (height != null) {
+            height.setValue(deriveDPFrom(cvi.getContext(), cvi.getPerpendicularLength()));
+        }
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoice.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoice.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk.choosegenerator;
+
+import android.support.annotation.NonNull;
+
+import com.fuzz.indicator.LayeredViewGenerator;
+
+/**
+ * Simple object holding model data about a {@link LayeredViewGenerator}.
+ * <p>
+ *     {@link #type} is a reference to the exact class this encapsulates,
+ *     while {@link #description} is a user-friendly description of its
+ *     purpose and usage.
+ * </p>
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public class GeneratorChoice {
+    @NonNull
+    protected final Class<? extends LayeredViewGenerator> type;
+    @NonNull
+    protected final String description;
+
+    public GeneratorChoice(@NonNull Class<? extends LayeredViewGenerator> type, @NonNull String description) {
+        this.type = type;
+        this.description = description;
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
@@ -45,7 +45,7 @@ public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
     public GeneratorChoiceAdapter() {
         choices.add(new GeneratorChoice(ImageViewGenerator.class, "Creates simple ImageViews. These are offset with X or Y translations. A classic choice with static background and dynamic content."));
         choices.add(new GeneratorChoice(ClippedImageViewGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageViewGenerator."));
-        choices.add(new GeneratorChoice(BoldTextViewGenerator.class, "Creates TextViews with bold text. These are offset based on the index within the TextViews' text. Rather new and difficult to master."));
+        choices.add(new GeneratorChoice(BoldTextViewGenerator.class, "Creates TextViews with bold text. The bold sections are offset in a dynamic manner within the TextViews' text. Rather new and difficult to master."));
     }
 
     public void setChosen(@NonNull Class<? extends LayeredViewGenerator> chosen) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk.choosegenerator;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.fuzz.emptyhusk.BoldTextViewGenerator;
+import com.fuzz.emptyhusk.R;
+import com.fuzz.indicator.ImageViewGenerator;
+import com.fuzz.indicator.LayeredViewGenerator;
+import com.fuzz.indicator.clip.ClippedImageViewGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
+
+    @NonNull
+    private List<GeneratorChoice> choices = new ArrayList<>();
+
+    @NonNull
+    private Class<? extends LayeredViewGenerator> chosen = ImageViewGenerator.class;
+
+    public GeneratorChoiceAdapter() {
+        choices.add(new GeneratorChoice(ImageViewGenerator.class, "Creates simple ImageViews. These are offset with X or Y translations. A classic choice with static background and dynamic content."));
+        choices.add(new GeneratorChoice(ClippedImageViewGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageViewGenerator."));
+        choices.add(new GeneratorChoice(BoldTextViewGenerator.class, "Creates TextViews with bold text. These are offset based on the index within the TextViews' text. Rather new and difficult to master."));
+    }
+
+    public void setChosen(@NonNull Class<? extends LayeredViewGenerator> chosen) {
+        int oldPosition = indexOf(this.chosen);
+        int newPosition = indexOf(chosen);
+        this.chosen = chosen;
+
+        if (oldPosition != -1) {
+            notifyItemChanged(oldPosition);
+        }
+        if (newPosition != -1) {
+            notifyItemChanged(newPosition);
+        }
+    }
+
+    private int indexOf(Class<? extends LayeredViewGenerator> chosen) {
+        int position = -1;
+        for (int i = 0; i < choices.size(); i++) {
+            GeneratorChoice choice = choices.get(i);
+            if (choice.type == chosen) {
+                position = i;
+                break;
+            }
+        }
+        return position;
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        View itemView = inflater.inflate(R.layout.cell_generator, parent, false);
+        return new GeneratorViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        final GeneratorChoice choice = choices.get(position);
+        GeneratorViewHolder generatorViewHolder = (GeneratorViewHolder) holder;
+        generatorViewHolder.title.setText(choice.type.getSimpleName());
+        generatorViewHolder.description.setText(choice.description);
+        generatorViewHolder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (chosen != choice.type) {
+                    setChosen(choice.type);
+                }
+            }
+        });
+        generatorViewHolder.setSelected(chosen == choice.type);
+    }
+
+    @NonNull
+    public Class<? extends LayeredViewGenerator> getChosen() {
+        return chosen;
+    }
+
+    @Override
+    public int getItemCount() {
+        return choices.size();
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceFragment.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceFragment.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk.choosegenerator;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnClickListener;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+
+import com.fuzz.emptyhusk.R;
+import com.fuzz.indicator.LayeredViewGenerator;
+
+import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
+
+/**
+ * A specialised dialog to bring up a {@link GeneratorChoiceAdapter}, allowing the user
+ * to select among the demo implementations of {@link LayeredViewGenerator} included
+ * in this app.
+ * <p>
+ *     Please create instances via the static {@link #newInstance(Class)} method - this
+ *     ensures that the previously-selected Generator appears selected when this dialog
+ *     appears on screen.
+ * </p>
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public class GeneratorChoiceFragment extends DialogFragment {
+
+    public static final String TAG = GeneratorChoiceFragment.class.getSimpleName();
+
+    private static final String ARG_PRESELECT = TAG + "-preselect";
+
+    @NonNull
+    protected GeneratorChoiceAdapter adapter = new GeneratorChoiceAdapter();
+
+    @Nullable
+    protected OnSelectedListener<Class<? extends LayeredViewGenerator>> onSelectedListener;
+
+    public static GeneratorChoiceFragment newInstance(@NonNull Class<? extends LayeredViewGenerator> present) {
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_PRESELECT, present);
+
+        GeneratorChoiceFragment fragment = new GeneratorChoiceFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public void setOnSelectedListener(@Nullable OnSelectedListener<Class<? extends LayeredViewGenerator>> onSelectedListener) {
+        this.onSelectedListener = onSelectedListener;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        OnClickListener positiveListener = new OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if (onSelectedListener != null) {
+                    onSelectedListener.onSelected(adapter.getChosen());
+                }
+                dismiss();
+            }
+        };
+
+        adapter.setChosen(getChosenFrom(getArguments()));
+
+        return createRecyclerViewBasedDialog(adapter, positiveListener);
+    }
+
+    protected Dialog createRecyclerViewBasedDialog(GeneratorChoiceAdapter adapter, OnClickListener positiveListener) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), getTheme());
+
+        LayoutInflater inflater = LayoutInflater.from(builder.getContext());
+
+        RecyclerView rootView = (RecyclerView) inflater.inflate(R.layout.dialog_generator, null, false);
+        rootView.setAdapter(adapter);
+        rootView.setLayoutManager(new LinearLayoutManager(getActivity(), VERTICAL, false));
+
+        return builder
+                .setPositiveButton("Change", positiveListener)
+                .setNegativeButton("Cancel", new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dismiss();
+                    }
+                })
+                .setView(rootView)
+                .create();
+    }
+
+    @NonNull
+    private Class<? extends LayeredViewGenerator> getChosenFrom(@Nullable Bundle bundle) {
+        Class<? extends LayeredViewGenerator> chosen = null;
+        if (bundle != null) {
+            //noinspection unchecked
+            chosen = (Class<? extends LayeredViewGenerator>) bundle.getSerializable(ARG_PRESELECT);
+        }
+        if (chosen == null) {
+            throw new IllegalStateException("This class must be seeded with a non-null preselection.");
+        }
+        return chosen;
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorViewHolder.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorViewHolder.java
@@ -1,0 +1,34 @@
+package com.fuzz.emptyhusk.choosegenerator;
+
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.fuzz.emptyhusk.R;
+
+/**
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+class GeneratorViewHolder extends RecyclerView.ViewHolder {
+    protected TextView title;
+    protected TextView description;
+
+    public GeneratorViewHolder(View itemView) {
+        super(itemView);
+        title = (TextView) itemView.findViewById(R.id.title);
+        description = (TextView) itemView.findViewById(R.id.description);
+    }
+
+    public void setSelected(boolean selected) {
+        PorterDuffColorFilter filter;
+        if (selected) {
+            filter = new PorterDuffColorFilter(Color.LTGRAY, PorterDuff.Mode.SRC_ATOP);
+        } else {
+            filter = null;
+        }
+        itemView.getBackground().setColorFilter(filter);
+    }
+}

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorViewHolder.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.emptyhusk.choosegenerator;
 
 import android.graphics.Color;

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/OnSelectedListener.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/OnSelectedListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fuzz.emptyhusk.choosegenerator;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Counterpart to {@link android.widget.AdapterView.OnItemSelectedListener} that
+ * isn't tied to {@link android.widget.AdapterView}.
+ *
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+public interface OnSelectedListener<T> {
+    /**
+     * Whatever was asking the user to select will have disappeared by the
+     * time this method is called
+     * @param chosen the item chosen (may not be null)
+     */
+    void onSelected(@NonNull T chosen);
+}

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -18,6 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:husk="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"

--- a/mobile/src/main/res/layout/cell_generator.xml
+++ b/mobile/src/main/res/layout/cell_generator.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2016 Philip Cohn-Cort
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:padding="4dp"
+    android:background="@color/colorTertiary"
+    >
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:textColor="@color/colorPrimary"
+        tools:text="Cool Generator"
+        />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginRight="80dp"
+        android:layout_marginEnd="80dp"
+        android:background="@color/colorAccent"
+        />
+
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        tools:text="This generator makes splashy animations run in real time. Change values faster to trigger more dramatic side effects!"
+        />
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/dialog_generator.xml
+++ b/mobile/src/main/res/layout/dialog_generator.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright 2016 Philip Cohn-Cort
 
@@ -13,15 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<resources>
-    <string name="app_name">EmptyHusk</string>
-    <string name="title_activity_main">CutoutViewIndicator Demo</string>
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/recyclerview"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    tools:listitem="@layout/cell_generator"
+    >
 
-    <string name="label_margin">Spacing</string>
-    <string name="label_height">Height</string>
-    <string name="label_width">Width</string>
-    <string name="label_unify">Change All</string>
-    <string name="label_orientation">Vertical?</string>
-
-    <string name="action_change_generator">Change Generator....</string>
-</resources>
+</android.support.v7.widget.RecyclerView>

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/changeGenerator"
+        android:title="@string/action_change_generator"
+        />
+</menu>

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2016 Philip Cohn-Cort
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/changeGenerator"


### PR DESCRIPTION
Darn. Kinda wish the enter key didn't just create pull requests instantaneously.....

Anyway. This allows the mobile app to swap generators at runtime, choosing from any of the subclasses of LayeredViewGenerator specified in `GeneratorChoiceAdapter`'s `choices` collection. This collection will need to be more dynamic in the future, but for now it looks to be working ok.