### PR TITLE
Issue #30: reshape state proxy

### DIFF
--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -206,8 +206,7 @@ public class CutoutViewIndicator extends LinearLayout {
             a.recycle();
         }
         if (isInEditMode()) {
-            // We don't use setStateProxy because that could have side effects.
-            stateProxy = EDIT_MODE_PROXY;
+            setStateProxy(EDIT_MODE_PROXY);
         }
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -49,6 +49,18 @@ public class CutoutViewIndicator extends LinearLayout {
     private static final String TAG = CutoutViewIndicator.class.getSimpleName();
 
     /**
+     * Specialised implementation of {@link UnavailableProxy} for use with
+     * {@linkplain #isInEditMode() the preview tools}.
+     */
+    protected static final UnavailableProxy EDIT_MODE_PROXY = new UnavailableProxy() {
+        @Override
+        public void resendPositionInfo(CutoutViewIndicator cvi, float pos) {
+            int atView = (int) pos;
+            cvi.showOffsetIndicator(cvi.fixPosition(atView), pos - atView);
+        }
+    };
+
+    /**
      * This holds onto the views that may be attached to this ViewGroup. It's initialised
      * with space for 5 values because practical experience says that space for 10 would
      * be excessive.
@@ -135,7 +147,7 @@ public class CutoutViewIndicator extends LinearLayout {
                 // Quantity isn't changing.
             }
 
-            stateProxy.resendPositionInfo(getCurrentIndicatorPosition());
+            stateProxy.resendPositionInfo(CutoutViewIndicator.this, getCurrentIndicatorPosition());
         }
 
         /**
@@ -195,13 +207,7 @@ public class CutoutViewIndicator extends LinearLayout {
         }
         if (isInEditMode()) {
             // We don't use setStateProxy because that could have side effects.
-            stateProxy = new UnavailableProxy() {
-                @Override
-                public void resendPositionInfo(float pos) {
-                    int atView = (int) pos;
-                    showOffsetIndicator(fixPosition(atView), pos - atView);
-                }
-            };
+            stateProxy = EDIT_MODE_PROXY;
         }
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/OnViewPagerChangeListener.java
+++ b/indicator/src/main/java/com/fuzz/indicator/OnViewPagerChangeListener.java
@@ -51,7 +51,17 @@ public class OnViewPagerChangeListener implements ViewPager.OnPageChangeListener
 
     @Override
     public void onPageSelected(int position) {
-        cvi.showOffsetIndicator(cvi.fixPosition(position), 0);
+        onPageSelected(cvi, position);
+    }
+
+    /**
+     * Integration implementation of {@link #onPageSelected(int)} for use with
+     * {@link ViewPagerStateProxy#resendPositionInfo(CutoutViewIndicator, float)}.
+     * @param cvi         which CutoutViewIndicator to call methods on.
+     * @param position    a specified position within the indicator.
+     */
+    public void onPageSelected(CutoutViewIndicator cvi, float position) {
+        cvi.showOffsetIndicator(cvi.fixPosition((int)position), position - (int)position);
     }
 
     @Override

--- a/indicator/src/main/java/com/fuzz/indicator/StateProxy.java
+++ b/indicator/src/main/java/com/fuzz/indicator/StateProxy.java
@@ -46,12 +46,14 @@ public interface StateProxy {
      * This method is called when the {@link CutoutViewIndicator} has just
      * rebuilt its views.
      *
+     * @param cvi                         the CutoutViewIndicator to which
+     *                                    new info should be sent
      * @param assumedIndicatorPosition    the position which the indicator
      *                                    thinks is selected, may or may
      *                                    not be the same as
      *                                    {@link #getCurrentPosition()}.
      */
-    void resendPositionInfo(float assumedIndicatorPosition);
+    void resendPositionInfo(CutoutViewIndicator cvi, float assumedIndicatorPosition);
 
     /**
      * This method is called when the {@link CutoutViewIndicator} is ready

--- a/indicator/src/main/java/com/fuzz/indicator/UnavailableProxy.java
+++ b/indicator/src/main/java/com/fuzz/indicator/UnavailableProxy.java
@@ -35,7 +35,7 @@ public class UnavailableProxy implements StateProxy {
     }
 
     @Override
-    public void resendPositionInfo(float assumedIndicatorPosition) {
+    public void resendPositionInfo(CutoutViewIndicator cvi, float assumedIndicatorPosition) {
         // Do nothing
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/ViewPagerStateProxy.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ViewPagerStateProxy.java
@@ -31,7 +31,7 @@ public class ViewPagerStateProxy implements StateProxy {
     private final ViewPager pager;
 
     @NonNull
-    private ViewPager.OnPageChangeListener pageChangeListener;
+    private OnViewPagerChangeListener pageChangeListener;
 
     public ViewPagerStateProxy(@NonNull ViewPager pager, @NonNull CutoutViewIndicator cvi) {
         this.pager = pager;
@@ -52,7 +52,7 @@ public class ViewPagerStateProxy implements StateProxy {
     @Override
     public void resendPositionInfo(CutoutViewIndicator cvi, float assumedIndicatorPosition) {
         // We blindly trust that the assumed position is accurate.
-        pageChangeListener.onPageSelected((int) assumedIndicatorPosition);
+        pageChangeListener.onPageSelected(cvi, assumedIndicatorPosition);
     }
 
     @Override

--- a/indicator/src/main/java/com/fuzz/indicator/ViewPagerStateProxy.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ViewPagerStateProxy.java
@@ -50,7 +50,7 @@ public class ViewPagerStateProxy implements StateProxy {
     }
 
     @Override
-    public void resendPositionInfo(float assumedIndicatorPosition) {
+    public void resendPositionInfo(CutoutViewIndicator cvi, float assumedIndicatorPosition) {
         // We blindly trust that the assumed position is accurate.
         pageChangeListener.onPageSelected((int) assumedIndicatorPosition);
     }

--- a/mobile/src/androidTest/java/com/fuzz/indicator/ConstantStateProxy.java
+++ b/mobile/src/androidTest/java/com/fuzz/indicator/ConstantStateProxy.java
@@ -47,8 +47,8 @@ public class ConstantStateProxy implements StateProxy {
     }
 
     @Override
-    public void resendPositionInfo(float assumedIndicatorPosition) {
-        // TODO: refactor API so that the CutoutViewIndicator itself is guaranteed accessible from this method
+    public void resendPositionInfo(CutoutViewIndicator cvi, float position) {
+        cvi.showOffsetIndicator(cvi.fixPosition((int) position), position - (int) position);
     }
 
     @Override


### PR DESCRIPTION
This ensures that each `StateProxy` gets the information it needs, when it's needed. Our edit-mode `StateProxy` is no longer directly set on the field, since `setStateProxy` side-effects have been fully vetted.