### PR TITLE
Issue #42: rename classes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# [0.5.x SNAPSHOT]
+## Rename classes
+
+### Library changes:
+* Rename: `LayeredView` -> `CutoutCell` ([#42])
+* Rename: `LayeredViewGenerator` -> `CutoutCellGenerator` ([#42])
+* Allow xml definition of `LayeredViewGenerator` implementation ([#38])
+
 # [0.5.1]
 ## Correct javadoc problems
 
@@ -79,4 +87,6 @@
 [#33]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/33
 [#35]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/35
 [#36]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/36
+[#38]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/38
 [#40]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/40
+[#42]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/42

--- a/indicator/src/main/java/com/fuzz/indicator/CCGFactory.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CCGFactory.java
@@ -9,12 +9,12 @@ import java.lang.reflect.InvocationTargetException;
 import static com.fuzz.indicator.reflect.ReConstructor.constructFrom;
 
 /**
- * Reflection-based utility class for creating {@link LayeredViewGenerator}s on
+ * Reflection-based utility class for creating {@link CutoutCellGenerator}s on
  * the fly. May be called by the constructors in {@link CutoutViewIndicator}.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class LVGFactory {
+public class CCGFactory {
 
     public static void constructGeneratorFrom(
             @NonNull Context context,
@@ -23,23 +23,23 @@ public class LVGFactory {
             @NonNull String generatorName,
             @NonNull ConstructorCallback callback
     ) {
-        LayeredViewGenerator generator = null;
+        CutoutCellGenerator generator = null;
 
         String message = "";
         try {
-            generator = constructFrom(LayeredViewGenerator.class, context, attrs, defStyleAttr, generatorName);
+            generator = constructFrom(CutoutCellGenerator.class, context, attrs, defStyleAttr, generatorName);
         } catch (ClassNotFoundException ignored) {
-            message = "The specified LayeredViewGenerator cannot be found." +
+            message = "The specified CutoutCellGenerator cannot be found." +
                     " Make sure the class reference on rcv_generator_class_name" +
                     " (\'" + generatorName + "\')" +
                     " matches a class in the same ClassLoader as this layout's" +
                     " context.";
         } catch (InvocationTargetException ite) {
-            message = "The constructor of the new LayeredViewGenerator threw this: " + ite.getCause();
+            message = "The constructor of the new CutoutCellGenerator threw this: " + ite.getCause();
         } catch (Exception e) {
             message = "The following arose while trying to resolve the" +
                     " the rcv_generator_class_name=\"" + generatorName +
-                    "\" attribute as a LayeredViewGenerator: " + e.toString();
+                    "\" attribute as a CutoutCellGenerator: " + e.toString();
         } finally {
             if (generator == null) {
                 message += "\nCutoutViewIndicator didn't have access to a working" +

--- a/indicator/src/main/java/com/fuzz/indicator/ConstructorCallback.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ConstructorCallback.java
@@ -6,13 +6,13 @@ import android.util.AttributeSet;
 
 /**
  * Interface for performing actions after
- * {@link LVGFactory#constructGeneratorFrom(Context, AttributeSet, int, String, ConstructorCallback)}
+ * {@link CCGFactory#constructGeneratorFrom(Context, AttributeSet, int, String, ConstructorCallback)}
  * finishes.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
 public interface ConstructorCallback {
-    void onGenerated(@NonNull LayeredViewGenerator generator);
+    void onGenerated(@NonNull CutoutCellGenerator generator);
 
     void onFailed(@NonNull String message);
 }

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutCell.java
@@ -20,6 +20,12 @@ import android.view.View;
 
 /**
  * Simple interface which views inside the {@link CutoutViewIndicator} should implement.
+ * <p>
+ *     Views may instead be wrapped in an implementation of this class before being
+ *     returned by the CutoutViewIndicator's {@link CutoutCellGenerator} - see
+ *     {@link CutoutViewIndicator#createCellFor(int)} and {@link TypicalCutoutCell}
+ *     for more details.
+ * </p>
  *
  * @author Philip Cohn-Cort (Fuzz)
  */

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutCell.java
@@ -15,25 +15,27 @@
  */
 package com.fuzz.indicator;
 
-import android.graphics.Matrix;
 import android.support.annotation.NonNull;
-import android.widget.ImageView;
+import android.view.View;
 
 /**
- * A simple LayeredView implementation that performs a 2D-shift of
- * ImageView content over its background.
+ * Simple interface which views inside the {@link CutoutViewIndicator} should implement.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class LayeredImageViewHolder extends IndicatorViewHolder<ImageView> {
+public interface CutoutCell {
 
-    public LayeredImageViewHolder(ImageView itemView) {
-        super(itemView);
-    }
+    /**
+     * Perform some arbitrary action to represent the provided OffsetEvent.
+     *
+     * @param offsetEvent    whatever just happened
+     * @see OffSetters
+     */
+    void offsetContentBy(@NonNull IndicatorOffsetEvent offsetEvent);
 
-    @Override
-    public void offsetContentBy(@NonNull IndicatorOffsetEvent event) {
-        OffSetters.offsetImageBy(itemView, event.getOrientation(), event.getFraction(), new Matrix());
-    }
-
+    /**
+     * @return the actual view represented by this object
+     */
+    @NonNull
+    View getItemView();
 }

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutCellGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutCellGenerator.java
@@ -31,7 +31,7 @@ import android.view.ViewGroup;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public interface LayeredViewGenerator {
+public interface CutoutCellGenerator {
     /**
      * The caller will likely throw an Exception if the returned View is attached
      * to a {@link android.view.ViewParent}.

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
@@ -25,7 +25,7 @@ import android.widget.ImageView;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class CutoutImageCell extends IndicatorViewHolder<ImageView> {
+public class CutoutImageCell extends TypicalCutoutCell<ImageView> {
 
     public CutoutImageCell(ImageView itemView) {
         super(itemView);

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
@@ -15,27 +15,25 @@
  */
 package com.fuzz.indicator;
 
+import android.graphics.Matrix;
 import android.support.annotation.NonNull;
-import android.view.View;
+import android.widget.ImageView;
 
 /**
- * Simple interface which views inside the {@link CutoutViewIndicator} should implement.
+ * A simple CutoutCell implementation that performs a 2D-shift of
+ * ImageView content over its background.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public interface LayeredView {
+public class CutoutImageCell extends IndicatorViewHolder<ImageView> {
 
-    /**
-     * Perform some arbitrary action to represent the provided OffsetEvent.
-     *
-     * @param offsetEvent    whatever just happened
-     * @see OffSetters
-     */
-    void offsetContentBy(@NonNull IndicatorOffsetEvent offsetEvent);
+    public CutoutImageCell(ImageView itemView) {
+        super(itemView);
+    }
 
-    /**
-     * @return the actual view represented by this object
-     */
-    @NonNull
-    View getItemView();
+    @Override
+    public void offsetContentBy(@NonNull IndicatorOffsetEvent event) {
+        OffSetters.offsetImageBy(itemView, event.getOrientation(), event.getFraction(), new Matrix());
+    }
+
 }

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -44,7 +44,7 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
  * A RecyclerView-inspired ViewGroup for showing an indicator traversing multiple child Views ('cells').
  * <p>
  * There's a nice monospace line drawing in the javadoc for {@link #showOffsetIndicator(int, float)} that basically sums up
- * its appearance when operating under an {@link ImageViewGenerator}.
+ * its appearance when operating under an {@link ImageCellGenerator}.
  * </p>
  *
  * @author Philip Cohn-Cort (Fuzz)
@@ -107,7 +107,7 @@ public class CutoutViewIndicator extends LinearLayout {
      * @see #showOffsetIndicator(int, float)
      */
     @NonNull
-    protected LayeredViewGenerator generator;
+    protected CutoutCellGenerator generator;
 
     @NonNull
     protected LayoutLogger logger;
@@ -189,7 +189,7 @@ public class CutoutViewIndicator extends LinearLayout {
         super(context, attrs, defStyleAttr);
 
         logger = LayoutLogger.getPreferred(isInEditMode());
-        generator = new ImageViewGenerator();
+        generator = new ImageCellGenerator();
         defaultChildParams = new CutoutViewLayoutParams(WRAP_CONTENT, WRAP_CONTENT);
 
         init(context, attrs, defStyleAttr);
@@ -200,7 +200,7 @@ public class CutoutViewIndicator extends LinearLayout {
         super(context, attrs, defStyleAttr, defStyleRes);
 
         logger = LayoutLogger.getPreferred(isInEditMode());
-        generator = new ImageViewGenerator();
+        generator = new ImageCellGenerator();
         defaultChildParams = new CutoutViewLayoutParams(WRAP_CONTENT, WRAP_CONTENT);
 
         init(context, attrs, defStyleAttr);
@@ -228,9 +228,9 @@ public class CutoutViewIndicator extends LinearLayout {
 
             String generatorName = a.getString(R.styleable.CutoutViewIndicator_rcv_generator_class_name);
             if (generatorName != null) {
-                LVGFactory.constructGeneratorFrom(context, attrs, defStyleAttr, generatorName, new ConstructorCallback() {
+                CCGFactory.constructGeneratorFrom(context, attrs, defStyleAttr, generatorName, new ConstructorCallback() {
                     @Override
-                    public void onGenerated(@NonNull LayeredViewGenerator generated) {
+                    public void onGenerated(@NonNull CutoutCellGenerator generated) {
                         CutoutViewIndicator.this.generator = generated;
                     }
 
@@ -262,7 +262,7 @@ public class CutoutViewIndicator extends LinearLayout {
      * Most child views this ViewGroup will see are created by
      * {@link #createCellFor(int)} and added to this by the
      * {@link #dataSetObserver}. These objects all have non-null
-     * LayeredViews associated with them.
+     * CutoutCells associated with them.
      * <p>
      *     Note that all other addView methods will ultimately call into
      *     this one. Any child view that has not already been associated
@@ -274,7 +274,7 @@ public class CutoutViewIndicator extends LinearLayout {
     @Override
     public void addView(View child, int index, ViewGroup.LayoutParams params) {
         super.addView(child, index, params);
-        // LayeredView's Views are always added at exact indices. If there is no value
+        // A CutoutCell's Views are always added at exact indices. If there is no value
         // in this.holders for the given index, we need to set that right away.
         int realIndex = indexOfChild(child);
 
@@ -311,7 +311,7 @@ public class CutoutViewIndicator extends LinearLayout {
                 && child.getScaleType() != ImageView.ScaleType.MATRIX) {
             String tag = "resources.insufficient";
             String message = "Only child ImageViews with a MATRIX scaleType are respected by" +
-                    " your choice of LayeredView. Offset effects will not appear properly on" +
+                    " your choice of CutoutCell. Offset effects will not appear properly on" +
                     " ScaleType " + child.getScaleType() + ".";
             logger.logToLayoutLib(tag, message);
         }
@@ -390,7 +390,7 @@ public class CutoutViewIndicator extends LinearLayout {
      * Set a new generator that will be called upon when a new cell
      * is needed. More or less the same as RecyclerView's Adapter.
      * <p>
-     *     Defaults to being a {@link ImageViewGenerator}, which
+     *     Defaults to being a {@link ImageCellGenerator}, which
      *     should be good enough for most purposes.
      * </p>
      * This method ends by calling {@link #rebuildChildViews()}.
@@ -398,7 +398,7 @@ public class CutoutViewIndicator extends LinearLayout {
      * @param generator the new generator. May not be null.
      * @see #showOffsetIndicator(int, float)
      */
-    public void setGenerator(@NonNull LayeredViewGenerator generator) {
+    public void setGenerator(@NonNull CutoutCellGenerator generator) {
         this.generator = generator;
         rebuildChildViews();
     }
@@ -407,7 +407,7 @@ public class CutoutViewIndicator extends LinearLayout {
      * Utility method for invalidating the {@link #generator} (so to speak).
      * <p>
      *     It'll ensure that the child views match both what the current
-     *     {@link LayeredViewGenerator} creates AND the params defined by
+     *     {@link CutoutCellGenerator} creates AND the params defined by
      *     {@link #defaultChildParams}.
      * </p>
      * Views which have been marked for
@@ -430,13 +430,13 @@ public class CutoutViewIndicator extends LinearLayout {
 
     /**
      * Returns a reference to the generator used to create and bind
-     * cells. Default value is an instance of {@link ImageViewGenerator}.
+     * cells. Default value is an instance of {@link ImageCellGenerator}.
      *
      * @return the generator currently in use
-     * @see #setGenerator(LayeredViewGenerator)
+     * @see #setGenerator(CutoutCellGenerator)
      */
     @NonNull
-    public LayeredViewGenerator getGenerator() {
+    public CutoutCellGenerator getGenerator() {
         return generator;
     }
 
@@ -445,7 +445,7 @@ public class CutoutViewIndicator extends LinearLayout {
      *
      * @param position used as 'index' parameter to {@link #addView(View, int)}
      * @return a new cell, appropriate for that position
-     * @see LayeredViewGenerator#createCellFor(ViewGroup, int)
+     * @see CutoutCellGenerator#createCellFor(ViewGroup, int)
      * @see #showOffsetIndicator(int, float)
      */
     @NonNull

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
@@ -126,8 +126,8 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
 
     /**
      * Use this to set the attached {@link CutoutCell} reference. This can
-     * be retrieved by {@link LayeredViewGenerator} implementations during
-     * {@link LayeredViewGenerator#onBindChild(View, CutoutViewLayoutParams, View)}
+     * be retrieved by {@link CutoutCellGenerator} implementations during
+     * {@link CutoutCellGenerator#onBindChild(View, CutoutViewLayoutParams, View)}
      * if they so wish.
      *
      * @param cutoutCell    a CutoutCell that would hopefully be defined

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
@@ -43,7 +43,7 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
     public int indicatorDrawableId;
 
     @NonNull
-    protected WeakReference<CutoutCell> viewHolder = new WeakReference<>(null);
+    protected WeakReference<CutoutCell> cutoutCell = new WeakReference<>(null);
 
     /**
      * Set this to true to prevent the attached view from being
@@ -135,20 +135,20 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
      *                       returns the same object that these LayoutParams
      *                       are set on.
      */
-    public void setViewHolder(@Nullable CutoutCell cutoutCell) {
-        this.viewHolder = new WeakReference<>(cutoutCell);
+    public void setCutoutCell(@Nullable CutoutCell cutoutCell) {
+        this.cutoutCell = new WeakReference<>(cutoutCell);
     }
 
     /**
-     * Getter counterpart to {@link #setViewHolder(CutoutCell)}. In general,
+     * Getter counterpart to {@link #setCutoutCell(CutoutCell)}. In general,
      * it is safe to assume that the value returned here is the same as that
      * most recently set.
      *
      * @return the associated CutoutCell if it has not been garbage-collected.
      */
     @Nullable
-    public CutoutCell getViewHolder() {
-        return viewHolder.get();
+    public CutoutCell getCutoutCell() {
+        return cutoutCell.get();
     }
 
     public void setFrom(@NonNull CutoutViewLayoutParams cutoutSource) {
@@ -157,7 +157,7 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
         internalSpacing = cutoutSource.internalSpacing;
         cellLength = cutoutSource.cellLength;
         perpendicularLength = cutoutSource.perpendicularLength;
-        viewHolder = cutoutSource.viewHolder;
+        cutoutCell = cutoutSource.cutoutCell;
     }
 
     /**

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewLayoutParams.java
@@ -43,7 +43,7 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
     public int indicatorDrawableId;
 
     @NonNull
-    protected WeakReference<LayeredView> viewHolder = new WeakReference<>(null);
+    protected WeakReference<CutoutCell> viewHolder = new WeakReference<>(null);
 
     /**
      * Set this to true to prevent the attached view from being
@@ -125,29 +125,29 @@ public class CutoutViewLayoutParams extends LinearLayout.LayoutParams {
     }
 
     /**
-     * Use this to set the attached {@link LayeredView} reference. This can
+     * Use this to set the attached {@link CutoutCell} reference. This can
      * be retrieved by {@link LayeredViewGenerator} implementations during
      * {@link LayeredViewGenerator#onBindChild(View, CutoutViewLayoutParams, View)}
      * if they so wish.
      *
-     * @param layeredView    a LayeredView that would hopefully be defined
-     *                       such that {@link LayeredView#getItemView()}
+     * @param cutoutCell    a CutoutCell that would hopefully be defined
+     *                       such that {@link CutoutCell#getItemView()}
      *                       returns the same object that these LayoutParams
      *                       are set on.
      */
-    public void setViewHolder(@Nullable LayeredView layeredView) {
-        this.viewHolder = new WeakReference<>(layeredView);
+    public void setViewHolder(@Nullable CutoutCell cutoutCell) {
+        this.viewHolder = new WeakReference<>(cutoutCell);
     }
 
     /**
-     * Getter counterpart to {@link #setViewHolder(LayeredView)}. In general,
+     * Getter counterpart to {@link #setViewHolder(CutoutCell)}. In general,
      * it is safe to assume that the value returned here is the same as that
      * most recently set.
      *
-     * @return the associated LayeredView if it has not been garbage-collected.
+     * @return the associated CutoutCell if it has not been garbage-collected.
      */
     @Nullable
-    public LayeredView getViewHolder() {
+    public CutoutCell getViewHolder() {
         return viewHolder.get();
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/ImageCellGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ImageCellGenerator.java
@@ -48,7 +48,7 @@ public class ImageCellGenerator implements CutoutCellGenerator {
         child.setImageResource(lp.indicatorDrawableId);
 
         CutoutCell cutoutCell = createCellForExisting(child);
-        lp.setViewHolder(cutoutCell);
+        lp.setCutoutCell(cutoutCell);
         return cutoutCell;
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/ImageCellGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ImageCellGenerator.java
@@ -22,13 +22,13 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 /**
- * Default implementation of {@link LayeredViewGenerator}.
+ * Default implementation of {@link CutoutCellGenerator}.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class ImageViewGenerator implements LayeredViewGenerator {
+public class ImageCellGenerator implements CutoutCellGenerator {
 
-    public ImageViewGenerator() {
+    public ImageCellGenerator() {
     }
 
     /**
@@ -47,7 +47,7 @@ public class ImageViewGenerator implements LayeredViewGenerator {
         child.setBackgroundResource(lp.cellBackgroundId);
         child.setImageResource(lp.indicatorDrawableId);
 
-        CutoutCell cutoutCell = createLayeredViewFor(child);
+        CutoutCell cutoutCell = createCellForExisting(child);
         lp.setViewHolder(cutoutCell);
         return cutoutCell;
     }
@@ -79,7 +79,7 @@ public class ImageViewGenerator implements LayeredViewGenerator {
      * implements CutoutCell in some way, it may be returned directly.
      */
     @NonNull
-    protected CutoutCell createLayeredViewFor(@NonNull ImageView child) {
+    protected CutoutCell createCellForExisting(@NonNull ImageView child) {
         return new CutoutImageCell(child);
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/ImageViewGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ImageViewGenerator.java
@@ -32,13 +32,13 @@ public class ImageViewGenerator implements LayeredViewGenerator {
     }
 
     /**
-     * Creates a new {@link LayeredImageViewHolder} by default. Override to change that.
+     * Creates a new {@link CutoutImageCell} by default. Override to change that.
      *
      * {@inheritDoc}
      */
     @NonNull
     @Override
-    public LayeredView createCellFor(@NonNull ViewGroup parent, int position) {
+    public CutoutCell createCellFor(@NonNull ViewGroup parent, int position) {
         CutoutViewLayoutParams lp = ((CutoutViewIndicator) parent).generateDefaultLayoutParams();
 
         ImageView child = createChildFor(parent, position);
@@ -47,9 +47,9 @@ public class ImageViewGenerator implements LayeredViewGenerator {
         child.setBackgroundResource(lp.cellBackgroundId);
         child.setImageResource(lp.indicatorDrawableId);
 
-        LayeredView layeredView = createLayeredViewFor(child);
-        lp.setViewHolder(layeredView);
-        return layeredView;
+        CutoutCell cutoutCell = createLayeredViewFor(child);
+        lp.setViewHolder(cutoutCell);
+        return cutoutCell;
     }
 
     /**
@@ -70,17 +70,17 @@ public class ImageViewGenerator implements LayeredViewGenerator {
 
     /**
      * This method is here to allow subclasses ease of overriding the exact
-     * type of {@link LayeredView} returned by {@link #createCellFor(ViewGroup, int)}.
+     * type of {@link CutoutCell} returned by {@link #createCellFor(ViewGroup, int)}.
      * <p>
      *     Could be handy for tests too.
      * </p>
      * @param child    the {@code View} part of the returned value
-     * @return a LayeredView wrapping {@code child}. If {@code child}
-     * implements LayeredView in some way, it may be returned directly.
+     * @return a CutoutCell wrapping {@code child}. If {@code child}
+     * implements CutoutCell in some way, it may be returned directly.
      */
     @NonNull
-    protected LayeredView createLayeredViewFor(@NonNull ImageView child) {
-        return new LayeredImageViewHolder(child);
+    protected CutoutCell createLayeredViewFor(@NonNull ImageView child) {
+        return new CutoutImageCell(child);
     }
 
     @Override

--- a/indicator/src/main/java/com/fuzz/indicator/IndicatorViewHolder.java
+++ b/indicator/src/main/java/com/fuzz/indicator/IndicatorViewHolder.java
@@ -29,7 +29,7 @@ import android.widget.ImageView;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public abstract class IndicatorViewHolder<Root extends View> implements LayeredView {
+public abstract class IndicatorViewHolder<Root extends View> implements CutoutCell {
     @NonNull
     protected final Root itemView;
 

--- a/indicator/src/main/java/com/fuzz/indicator/LayeredViewGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/LayeredViewGenerator.java
@@ -36,13 +36,13 @@ public interface LayeredViewGenerator {
      * The caller will likely throw an Exception if the returned View is attached
      * to a {@link android.view.ViewParent}.
      *
-     * @param parent the parent ViewGroup which the LayeredView will be added to
+     * @param parent the parent ViewGroup which the CutoutCell will be added to
      * @param position where (sequentially) in the {@link CutoutViewIndicator} this view will
      *                 appear
-     * @return a new {@code LayeredView}, which really shouldn't be null.
+     * @return a new {@code CutoutCell}, which really shouldn't be null.
      */
     @NonNull
-    LayeredView createCellFor(@NonNull ViewGroup parent, int position);
+    CutoutCell createCellFor(@NonNull ViewGroup parent, int position);
 
     /**
      * This will be called during the {@link CutoutViewIndicator}'s measure pass

--- a/indicator/src/main/java/com/fuzz/indicator/OffsetEvent.java
+++ b/indicator/src/main/java/com/fuzz/indicator/OffsetEvent.java
@@ -19,7 +19,7 @@ import android.graphics.Matrix;
 import android.text.Spannable;
 import android.widget.ImageView;
 
-import com.fuzz.indicator.text.LayeredTextViewHolder;
+import com.fuzz.indicator.text.CutoutTextCell;
 
 /**
  * This represents a single action or {@link android.view.MotionEvent} or whatever
@@ -30,12 +30,12 @@ import com.fuzz.indicator.text.LayeredTextViewHolder;
  */
 public interface OffsetEvent {
     /**
-     * If this is being used in a {@link LayeredImageViewHolder}, this fraction is multiplied
+     * If this is being used in a {@link CutoutImageCell}, this fraction is multiplied
      * by the {@link ImageView#getDrawable()} width/height to get a pixel offset - this
      * is then applied directly to the ImageView's Matrix via
      * {@link OffSetters#offsetImageBy(ImageView, int, float, Matrix)}.
      * <p>
-     *     {@link LayeredTextViewHolder} gets a similar treatment, except with
+     *     {@link CutoutTextCell} gets a similar treatment, except with
      *     spans instead of a Drawable. Details of that can be read from the
      *     javadoc for {@link OffSetters#offsetSpansBy(Spannable, float)}.
      * </p>

--- a/indicator/src/main/java/com/fuzz/indicator/TypicalCutoutCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/TypicalCutoutCell.java
@@ -15,25 +15,26 @@
  */
 package com.fuzz.indicator;
 
-import android.graphics.Matrix;
 import android.support.annotation.NonNull;
 import android.view.View;
-import android.widget.ImageView;
 
 /**
- * ViewHolder for a {@link CutoutViewIndicator}.
- *
- * Can be used like a {@link android.widget.ProgressBar}, only more straightforward.
- * <br/><br/>
- * Call {@link OffSetters#offsetImageBy(ImageView, int, float, Matrix)} to offset an image over a static background.
+ * Superclass for most cells in a {@link CutoutViewIndicator}. Of course,
+ * users of the library are welcome to implement their own
+ * {@link CutoutCell}s independently if they so desire.
+ * <p>
+ *     Subclasses should consider delegating their implementation of
+ *     {@link #offsetContentBy(IndicatorOffsetEvent)} to one of the
+ *     methods in {@link OffSetters}.
+ * </p>
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public abstract class IndicatorViewHolder<Root extends View> implements CutoutCell {
+public abstract class TypicalCutoutCell<Root extends View> implements CutoutCell {
     @NonNull
     protected final Root itemView;
 
-    public IndicatorViewHolder(@NonNull Root itemView) {
+    public TypicalCutoutCell(@NonNull Root itemView) {
         this.itemView = itemView;
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/ViewProvidingAdapter.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ViewProvidingAdapter.java
@@ -4,12 +4,15 @@ import android.support.annotation.Nullable;
 import android.view.View;
 
 /**
- * Implement this interface on your ViewPager's {@link android.support.v4.view.PagerAdapter
- * PagerAdapter} to enable support for passing views from
- * {@link ViewPagerStateProxy#getOriginalViewFor(int) your StateProxy}
- * to {@link LayeredViewGenerator#onBindChild(View,
- * CutoutViewLayoutParams, View) your generator}.
+ * Optional interface for your ViewPager's {@link android.support.v4.view.PagerAdapter
+ * PagerAdapter}.
+ * <p>
+ *     Implement it to enable support for passing views from
+ *     your StateProxy to your generator.
+ * </p>
  *
+ * @see ViewPagerStateProxy#getOriginalViewFor(int)
+ * @see CutoutCellGenerator#onBindChild(View, CutoutViewLayoutParams, View)
  * @author Philip Cohn-Cort (Fuzz)
  */
 public interface ViewProvidingAdapter {

--- a/indicator/src/main/java/com/fuzz/indicator/ViewProvidingStateProxy.java
+++ b/indicator/src/main/java/com/fuzz/indicator/ViewProvidingStateProxy.java
@@ -13,7 +13,7 @@ public interface ViewProvidingStateProxy extends StateProxy {
     /**
      * In some use cases, it may be handy to have a reference to the original
      * View when binding a representation thereof. See
-     * {@link LayeredViewGenerator#onBindChild(View, CutoutViewLayoutParams, View)}
+     * {@link CutoutCellGenerator#onBindChild(View, CutoutViewLayoutParams, View)}
      * for details.
      *
      * @param cviPosition    position of a child within the CutoutViewIndicator

--- a/indicator/src/main/java/com/fuzz/indicator/clip/ClippedImageCellGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/clip/ClippedImageCellGenerator.java
@@ -19,17 +19,17 @@ import android.support.annotation.NonNull;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
-import com.fuzz.indicator.ImageViewGenerator;
+import com.fuzz.indicator.ImageCellGenerator;
 import com.fuzz.indicator.widget.ClippedImageView;
 
 /**
- * Proxy variant of {@link ImageViewGenerator} that creates
+ * Proxy variant of {@link ImageCellGenerator} that creates
  * ClippedImageViews
  * in {@link #createChildFor(ViewGroup, int)}.
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class ClippedImageViewGenerator extends ImageViewGenerator {
+public class ClippedImageCellGenerator extends ImageCellGenerator {
     @NonNull
     @Override
     protected ImageView createChildFor(@NonNull ViewGroup parent, int position) {

--- a/indicator/src/main/java/com/fuzz/indicator/style/MigratorySpan.java
+++ b/indicator/src/main/java/com/fuzz/indicator/style/MigratorySpan.java
@@ -18,10 +18,10 @@ package com.fuzz.indicator.style;
 import android.support.annotation.NonNull;
 import android.text.Spannable;
 
-import com.fuzz.indicator.text.LayeredTextViewHolder;
+import com.fuzz.indicator.text.CutoutTextCell;
 
 /**
- * Interface to be implemented by spans used in {@link LayeredTextViewHolder}.
+ * Interface to be implemented by spans used in {@link CutoutTextCell}.
  *
  * These are designed to be translated (in a 2-dimensional plane) above
  * their associated {@link android.text.Spannable Spannables}.

--- a/indicator/src/main/java/com/fuzz/indicator/text/CutoutTextCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/text/CutoutTextCell.java
@@ -21,7 +21,7 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.widget.TextView;
 
-import com.fuzz.indicator.IndicatorViewHolder;
+import com.fuzz.indicator.TypicalCutoutCell;
 import com.fuzz.indicator.OffSetters;
 import com.fuzz.indicator.IndicatorOffsetEvent;
 
@@ -30,7 +30,7 @@ import com.fuzz.indicator.IndicatorOffsetEvent;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class CutoutTextCell extends IndicatorViewHolder<TextView> {
+public class CutoutTextCell extends TypicalCutoutCell<TextView> {
 
     public CutoutTextCell(@NonNull TextView child) {
         super(child);

--- a/indicator/src/main/java/com/fuzz/indicator/text/CutoutTextCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/text/CutoutTextCell.java
@@ -30,9 +30,9 @@ import com.fuzz.indicator.IndicatorOffsetEvent;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class LayeredTextViewHolder extends IndicatorViewHolder<TextView> {
+public class CutoutTextCell extends IndicatorViewHolder<TextView> {
 
-    public LayeredTextViewHolder(@NonNull TextView child) {
+    public CutoutTextCell(@NonNull TextView child) {
         super(child);
     }
 

--- a/indicator/src/main/java/com/fuzz/indicator/text/TextViewGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/text/TextViewGenerator.java
@@ -26,14 +26,14 @@ import android.widget.TextView;
 import com.fuzz.indicator.CutoutViewIndicator;
 import com.fuzz.indicator.CutoutViewLayoutParams;
 import com.fuzz.indicator.CutoutCell;
-import com.fuzz.indicator.LayeredViewGenerator;
+import com.fuzz.indicator.CutoutCellGenerator;
 
 /**
  * This generator is intended to animate stuff on TextViews
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public abstract class TextViewGenerator implements LayeredViewGenerator {
+public abstract class TextViewGenerator implements CutoutCellGenerator {
     @NonNull
     @Override
     public CutoutCell createCellFor(@NonNull ViewGroup parent, int position) {

--- a/indicator/src/main/java/com/fuzz/indicator/text/TextViewGenerator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/text/TextViewGenerator.java
@@ -25,7 +25,7 @@ import android.widget.TextView;
 
 import com.fuzz.indicator.CutoutViewIndicator;
 import com.fuzz.indicator.CutoutViewLayoutParams;
-import com.fuzz.indicator.LayeredView;
+import com.fuzz.indicator.CutoutCell;
 import com.fuzz.indicator.LayeredViewGenerator;
 
 /**
@@ -36,14 +36,14 @@ import com.fuzz.indicator.LayeredViewGenerator;
 public abstract class TextViewGenerator implements LayeredViewGenerator {
     @NonNull
     @Override
-    public LayeredView createCellFor(@NonNull ViewGroup parent, int position) {
+    public CutoutCell createCellFor(@NonNull ViewGroup parent, int position) {
         CutoutViewLayoutParams lp = ((CutoutViewIndicator) parent).generateDefaultLayoutParams();
 
         TextView child = new TextView(parent.getContext());
         child.setText(getTextFor(parent.getContext(), position));
         child.setLayoutParams(lp);
 
-        return new LayeredTextViewHolder(child);
+        return new CutoutTextCell(child);
     }
 
     @NonNull

--- a/indicator/src/main/res/values/attrs.xml
+++ b/indicator/src/main/res/values/attrs.xml
@@ -28,7 +28,7 @@
         <!-- width of each individual cell -->
         <attr name="rcv_width" format="dimension" />
 
-        <!-- class name of a preferred LayeredViewGenerator (defaults to ImageViewGenerator) -->
+        <!-- class name of a preferred CutoutCellGenerator (defaults to ImageCellGenerator) -->
         <attr name="rcv_generator_class_name" format="string" />
 
         <!-- space between successive cells -->

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 /**

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorWithInterfaceAbstractClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorWithInterfaceAbstractClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorWithoutInterfaceClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorWithoutInterfaceClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 /**

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorsClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PrivateConstructorsClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PublicConstructorClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PublicConstructorClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PublicConstructorThatExceptsClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PublicConstructorThatExceptsClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PublicSavedParametersClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PublicSavedParametersClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/PublicUnusableConstructorClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/PublicUnusableConstructorClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 /**

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/ReConstructorTest.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/ReConstructorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 import android.content.Context;

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/ReflectiveInterface.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/ReflectiveInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect;
 
 /**

--- a/indicator/src/test/java/com/fuzz/indicator/reflect/subpackage/PackagePrivateClass.java
+++ b/indicator/src/test/java/com/fuzz/indicator/reflect/subpackage/PackagePrivateClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Philip Cohn-Cort
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.fuzz.indicator.reflect.subpackage;
 
 import android.content.Context;

--- a/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextCellGenerator.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/BoldTextCellGenerator.java
@@ -33,7 +33,7 @@ import static android.graphics.Typeface.BOLD;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class BoldTextViewGenerator extends TextViewGenerator {
+public class BoldTextCellGenerator extends TextViewGenerator {
     @NonNull
     @Override
     protected Spannable getTextFor(@NonNull Context context, int position) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/MainActivity.java
@@ -34,7 +34,7 @@ import com.fuzz.emptyhusk.prefab.PlainActivity;
 import com.fuzz.emptyhusk.prefab.InlineViewPagerIndicatorFragment;
 import com.fuzz.emptyhusk.prefab.VerticalDotsFragment;
 import com.fuzz.indicator.CutoutViewIndicator;
-import com.fuzz.indicator.LayeredViewGenerator;
+import com.fuzz.indicator.CutoutCellGenerator;
 
 /**
  * Entry point into the sample application. This is designed to cover all the basic
@@ -58,10 +58,10 @@ public class MainActivity extends AppCompatActivity {
 
     protected PickerDelegate pickerDelegate;
 
-    protected OnSelectedListener<Class<? extends LayeredViewGenerator>> onGeneratorSelectedListener
-            = new OnSelectedListener<Class<? extends LayeredViewGenerator>>() {
+    protected OnSelectedListener<Class<? extends CutoutCellGenerator>> onGeneratorSelectedListener
+            = new OnSelectedListener<Class<? extends CutoutCellGenerator>>() {
         @Override
-        public void onSelected(@NonNull Class<? extends LayeredViewGenerator> chosen) {
+        public void onSelected(@NonNull Class<? extends CutoutCellGenerator> chosen) {
             try {
                 binding.cvi.setGenerator(chosen.newInstance());
             } catch (Exception e) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoice.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoice.java
@@ -17,10 +17,10 @@ package com.fuzz.emptyhusk.choosegenerator;
 
 import android.support.annotation.NonNull;
 
-import com.fuzz.indicator.LayeredViewGenerator;
+import com.fuzz.indicator.CutoutCellGenerator;
 
 /**
- * Simple object holding model data about a {@link LayeredViewGenerator}.
+ * Simple object holding model data about a {@link CutoutCellGenerator}.
  * <p>
  *     {@link #type} is a reference to the exact class this encapsulates,
  *     while {@link #description} is a user-friendly description of its
@@ -31,11 +31,11 @@ import com.fuzz.indicator.LayeredViewGenerator;
  */
 public class GeneratorChoice {
     @NonNull
-    protected final Class<? extends LayeredViewGenerator> type;
+    protected final Class<? extends CutoutCellGenerator> type;
     @NonNull
     protected final String description;
 
-    public GeneratorChoice(@NonNull Class<? extends LayeredViewGenerator> type, @NonNull String description) {
+    public GeneratorChoice(@NonNull Class<? extends CutoutCellGenerator> type, @NonNull String description) {
         this.type = type;
         this.description = description;
     }

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
@@ -22,7 +22,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.fuzz.emptyhusk.BoldTextViewGenerator;
+import com.fuzz.emptyhusk.BoldTextCellGenerator;
 import com.fuzz.emptyhusk.R;
 import com.fuzz.indicator.ImageCellGenerator;
 import com.fuzz.indicator.CutoutCellGenerator;
@@ -44,8 +44,8 @@ public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
 
     public GeneratorChoiceAdapter() {
         choices.add(new GeneratorChoice(ImageCellGenerator.class, "Creates simple ImageViews. These are offset with X or Y translations. A classic choice with static background and dynamic content."));
-        choices.add(new GeneratorChoice(ClippedImageCellGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageViewGenerator."));
-        choices.add(new GeneratorChoice(BoldTextViewGenerator.class, "Creates TextViews with bold text. The bold sections are offset in a dynamic manner within the TextViews' text. Rather new and difficult to master."));
+        choices.add(new GeneratorChoice(ClippedImageCellGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageCellGenerator."));
+        choices.add(new GeneratorChoice(BoldTextCellGenerator.class, "Creates TextViews with bold text. The bold sections are offset in a dynamic manner within the TextViews' text. Rather new and difficult to master."));
     }
 
     public void setChosen(@NonNull Class<? extends CutoutCellGenerator> chosen) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceAdapter.java
@@ -24,9 +24,9 @@ import android.view.ViewGroup;
 
 import com.fuzz.emptyhusk.BoldTextViewGenerator;
 import com.fuzz.emptyhusk.R;
-import com.fuzz.indicator.ImageViewGenerator;
-import com.fuzz.indicator.LayeredViewGenerator;
-import com.fuzz.indicator.clip.ClippedImageViewGenerator;
+import com.fuzz.indicator.ImageCellGenerator;
+import com.fuzz.indicator.CutoutCellGenerator;
+import com.fuzz.indicator.clip.ClippedImageCellGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,15 +40,15 @@ public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
     private List<GeneratorChoice> choices = new ArrayList<>();
 
     @NonNull
-    private Class<? extends LayeredViewGenerator> chosen = ImageViewGenerator.class;
+    private Class<? extends CutoutCellGenerator> chosen = ImageCellGenerator.class;
 
     public GeneratorChoiceAdapter() {
-        choices.add(new GeneratorChoice(ImageViewGenerator.class, "Creates simple ImageViews. These are offset with X or Y translations. A classic choice with static background and dynamic content."));
-        choices.add(new GeneratorChoice(ClippedImageViewGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageViewGenerator."));
+        choices.add(new GeneratorChoice(ImageCellGenerator.class, "Creates simple ImageViews. These are offset with X or Y translations. A classic choice with static background and dynamic content."));
+        choices.add(new GeneratorChoice(ClippedImageCellGenerator.class, "Creates ClippedImageViews. These are offset with X or Y translations. Stylish, yet ever so slightly heavier memory-wise than ImageViewGenerator."));
         choices.add(new GeneratorChoice(BoldTextViewGenerator.class, "Creates TextViews with bold text. The bold sections are offset in a dynamic manner within the TextViews' text. Rather new and difficult to master."));
     }
 
-    public void setChosen(@NonNull Class<? extends LayeredViewGenerator> chosen) {
+    public void setChosen(@NonNull Class<? extends CutoutCellGenerator> chosen) {
         int oldPosition = indexOf(this.chosen);
         int newPosition = indexOf(chosen);
         this.chosen = chosen;
@@ -61,7 +61,7 @@ public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
         }
     }
 
-    private int indexOf(Class<? extends LayeredViewGenerator> chosen) {
+    private int indexOf(Class<? extends CutoutCellGenerator> chosen) {
         int position = -1;
         for (int i = 0; i < choices.size(); i++) {
             GeneratorChoice choice = choices.get(i);
@@ -98,7 +98,7 @@ public class GeneratorChoiceAdapter extends RecyclerView.Adapter {
     }
 
     @NonNull
-    public Class<? extends LayeredViewGenerator> getChosen() {
+    public Class<? extends CutoutCellGenerator> getChosen() {
         return chosen;
     }
 

--- a/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceFragment.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/choosegenerator/GeneratorChoiceFragment.java
@@ -28,13 +28,13 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 
 import com.fuzz.emptyhusk.R;
-import com.fuzz.indicator.LayeredViewGenerator;
+import com.fuzz.indicator.CutoutCellGenerator;
 
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
 
 /**
  * A specialised dialog to bring up a {@link GeneratorChoiceAdapter}, allowing the user
- * to select among the demo implementations of {@link LayeredViewGenerator} included
+ * to select among the demo implementations of {@link CutoutCellGenerator} included
  * in this app.
  * <p>
  *     Please create instances via the static {@link #newInstance(Class)} method - this
@@ -54,9 +54,9 @@ public class GeneratorChoiceFragment extends DialogFragment {
     protected GeneratorChoiceAdapter adapter = new GeneratorChoiceAdapter();
 
     @Nullable
-    protected OnSelectedListener<Class<? extends LayeredViewGenerator>> onSelectedListener;
+    protected OnSelectedListener<Class<? extends CutoutCellGenerator>> onSelectedListener;
 
-    public static GeneratorChoiceFragment newInstance(@NonNull Class<? extends LayeredViewGenerator> present) {
+    public static GeneratorChoiceFragment newInstance(@NonNull Class<? extends CutoutCellGenerator> present) {
         Bundle args = new Bundle();
         args.putSerializable(ARG_PRESELECT, present);
 
@@ -65,7 +65,7 @@ public class GeneratorChoiceFragment extends DialogFragment {
         return fragment;
     }
 
-    public void setOnSelectedListener(@Nullable OnSelectedListener<Class<? extends LayeredViewGenerator>> onSelectedListener) {
+    public void setOnSelectedListener(@Nullable OnSelectedListener<Class<? extends CutoutCellGenerator>> onSelectedListener) {
         this.onSelectedListener = onSelectedListener;
     }
 
@@ -108,11 +108,11 @@ public class GeneratorChoiceFragment extends DialogFragment {
     }
 
     @NonNull
-    private Class<? extends LayeredViewGenerator> getChosenFrom(@Nullable Bundle bundle) {
-        Class<? extends LayeredViewGenerator> chosen = null;
+    private Class<? extends CutoutCellGenerator> getChosenFrom(@Nullable Bundle bundle) {
+        Class<? extends CutoutCellGenerator> chosen = null;
         if (bundle != null) {
             //noinspection unchecked
-            chosen = (Class<? extends LayeredViewGenerator>) bundle.getSerializable(ARG_PRESELECT);
+            chosen = (Class<? extends CutoutCellGenerator>) bundle.getSerializable(ARG_PRESELECT);
         }
         if (chosen == null) {
             throw new IllegalStateException("This class must be seeded with a non-null preselection.");

--- a/mobile/src/main/java/com/fuzz/emptyhusk/prefab/NarrowerSegmentsFragment.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/prefab/NarrowerSegmentsFragment.java
@@ -63,7 +63,7 @@ public class NarrowerSegmentsFragment extends Fragment {
             final CutoutViewIndicator cvi = (CutoutViewIndicator) view.findViewById(R.id.cutoutViewIndicator);
             initIndicator(recyclerView, cvi);
 
-            cvi.setGenerator(new ProportionalImageViewGenerator());
+            cvi.setGenerator(new ProportionalImageCellGenerator());
         }
     }
 

--- a/mobile/src/main/java/com/fuzz/emptyhusk/prefab/ProportionalImageCellGenerator.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/prefab/ProportionalImageCellGenerator.java
@@ -25,7 +25,7 @@ import android.widget.ImageView;
 
 import com.fuzz.emptyhusk.R;
 import com.fuzz.indicator.CutoutViewLayoutParams;
-import com.fuzz.indicator.clip.ClippedImageViewGenerator;
+import com.fuzz.indicator.clip.ClippedImageCellGenerator;
 
 /**
  * Generator for displaying clipped images which are proportional to
@@ -36,7 +36,7 @@ import com.fuzz.indicator.clip.ClippedImageViewGenerator;
  *
  * @author Philip Cohn-Cort (Fuzz)
  */
-public class ProportionalImageViewGenerator extends ClippedImageViewGenerator {
+public class ProportionalImageCellGenerator extends ClippedImageCellGenerator {
 
     protected int rvLength;
     protected int rvChildLength;

--- a/mobile/src/main/java/com/fuzz/emptyhusk/prefab/VerticalDotsFragment.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/prefab/VerticalDotsFragment.java
@@ -31,7 +31,7 @@ import android.view.ViewGroup;
 
 import com.fuzz.emptyhusk.R;
 import com.fuzz.indicator.CutoutViewIndicator;
-import com.fuzz.indicator.clip.ClippedImageViewGenerator;
+import com.fuzz.indicator.clip.ClippedImageCellGenerator;
 
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
@@ -94,7 +94,7 @@ public class VerticalDotsFragment extends Fragment {
      * @param cvi             a new CutoutViewIndicator
      */
     private void initIndicator(@NonNull RecyclerView recyclerView, @NonNull CutoutViewIndicator cvi) {
-        cvi.setGenerator(new ClippedImageViewGenerator());
+        cvi.setGenerator(new ClippedImageCellGenerator());
         cvi.setBackgroundColor(Color.BLACK);
         cvi.setCellLength(WRAP_CONTENT);
         cvi.setPerpendicularLength(WRAP_CONTENT);


### PR DESCRIPTION
Rename some classes to be much clearer about purposes and usage.

This should be the last set of changes (corresponding to issue #42 ) before the tagging of version 0.6.0.