### PR TITLE
Issue #51: provide methods to offset scale and alpha

### DIFF
--- a/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
@@ -41,20 +41,20 @@ public class CutoutImageCell extends TypicalCutoutCell<ImageView> {
 
     @Override
     public void offsetContentBy(@NonNull IndicatorOffsetEvent event) {
-        int flags = event.getOffSetFlags();
-        if ((flags & OffSetFlag.IMAGE_TRANSLATE) != 0) {
+        int hints = event.getOffSetHints();
+        if ((hints & OffSetHint.IMAGE_TRANSLATE) != 0) {
             OffSetters.offsetImageBy(itemView, event.getOrientation(), event.getFraction(), new Matrix());
         }
-        if ((flags & OffSetFlag.ALPHA) != 0) {
+        if ((hints & OffSetHint.ALPHA) != 0) {
             OffSetters.offsetAlphaBy(itemView, 1 + event.getFraction());
         }
-        if ((flags & OffSetFlag.IMAGE_ALPHA) != 0) {
+        if ((hints & OffSetHint.IMAGE_ALPHA) != 0) {
             OffSetters.offsetImageAlphaBy(itemView, 1 + event.getFraction());
         }
-        if ((flags & OffSetFlag.SCALE) != 0) {
+        if ((hints & OffSetHint.SCALE) != 0) {
             OffSetters.offsetScaleBy(itemView, 1 + event.getFraction());
         }
-        if ((flags & OffSetFlag.IMAGE_SCALE) != 0) {
+        if ((hints & OffSetHint.IMAGE_SCALE) != 0) {
             OffSetters.offsetImageScaleBy(itemView, 1 + event.getFraction());
         }
     }

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutImageCell.java
@@ -41,14 +41,30 @@ public class CutoutImageCell extends TypicalCutoutCell<ImageView> {
 
     @Override
     public void offsetContentBy(@NonNull IndicatorOffsetEvent event) {
-        OffSetters.offsetImageBy(itemView, event.getOrientation(), event.getFraction(), new Matrix());
+        int flags = event.getOffSetFlags();
+        if ((flags & OffSetFlag.IMAGE_TRANSLATE) != 0) {
+            OffSetters.offsetImageBy(itemView, event.getOrientation(), event.getFraction(), new Matrix());
+        }
+        if ((flags & OffSetFlag.ALPHA) != 0) {
+            OffSetters.offsetAlphaBy(itemView, 1 + event.getFraction());
+        }
+        if ((flags & OffSetFlag.IMAGE_ALPHA) != 0) {
+            OffSetters.offsetImageAlphaBy(itemView, 1 + event.getFraction());
+        }
+        if ((flags & OffSetFlag.SCALE) != 0) {
+            OffSetters.offsetScaleBy(itemView, 1 + event.getFraction());
+        }
+        if ((flags & OffSetFlag.IMAGE_SCALE) != 0) {
+            OffSetters.offsetImageScaleBy(itemView, 1 + event.getFraction());
+        }
     }
 
     /**
      * Call this whenever the view's bounds might have changed, or the layout params are different.
      * <p>
      *     This method delegates the choice of Drawable to
-     *     {@link #chooseDrawable(CutoutViewLayoutParams)}.
+     *     {@link #chooseDrawable(CutoutViewLayoutParams)}, which it then vets before setting
+     *     on the {@link #itemView}.
      * </p>
      *
      * @param lp    the LayoutParams {@link #itemView} should be assumed to have

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -132,23 +132,7 @@ public class CutoutViewIndicator extends LinearLayout {
 
             if (newViews > 0) {
                 // We're adding new views
-                for (int i = childCount; i < pageCount; i++) {
-                    // This is a cached view
-                    CutoutCell cell = cells.get(i);
-
-                    if (cell == null || cell.getItemView().getParent() != null) {
-                        // Current CutoutCell is nonexistent or already in use elsewhere...create and add a new one!
-                        if (cell != null && cell.getItemView().getParent() == CutoutViewIndicator.this) {
-                            Log.w(TAG, "It would appear that the view at " + i + " was not removed properly.");
-                        }
-
-                        cell = createCellFor(i);
-                        cells.put(i, cell);
-                    }
-
-                    // This will invalidate the added view, triggering a call to this class's onMeasure()
-                    addView(cell.getItemView(), i);
-                }
+                addNewViews(childCount, pageCount);
             } else if (newViews < 0) {
                 // We're removing views
                 removeViews(pageCount, -newViews);
@@ -161,6 +145,50 @@ public class CutoutViewIndicator extends LinearLayout {
             }
 
             stateProxy.resendPositionInfo(CutoutViewIndicator.this, getCurrentIndicatorPosition());
+        }
+
+        /**
+         * Calls {@link CutoutViewIndicator#addView} {@code pageCount - childCount} times. All new
+         * views added are placed at the end of the CutoutViewIndicator.
+         * <p>
+         *     If there is a non-null entry in {@link CutoutViewIndicator#cells} at the
+         *     position where this new view will be placed, then that value is queried
+         *     for its {@link CutoutCell#getItemView() itemView}. If that itemView is then
+         *     not null and not currently attached to a parent it will be added here.
+         * </p>
+         * <p>
+         *     However, if the CutoutCell's itemView <em>is</em> null or attached to a
+         *     {@link android.view.ViewParent parent}, it will not be used and a new
+         *     CutoutCell will be created (with a backing view) by
+         *     {@link CutoutViewIndicator#createCellFor(int)}.
+         * </p>
+         * At the end of this method, the entry in {@link CutoutViewIndicator#cells} for
+         * each position of a newly-added View will contain a reference to that View's
+         * {@link CutoutCell}.
+         * @param childCount    the number of views currently added as children of this
+         * {@link CutoutViewIndicator}
+         * @param pageCount     the number of children this CutoutViewIndicator should
+         *                      have to match the {@link CutoutViewIndicator#stateProxy}'s
+         *                      {@link StateProxy#getCellCount() cell count}.
+         */
+        protected void addNewViews(int childCount, int pageCount) {
+            for (int i = childCount; i < pageCount; i++) {
+                // This is a cached view
+                CutoutCell cell = cells.get(i);
+
+                if (cell == null || cell.getItemView().getParent() != null) {
+                    // Current CutoutCell is nonexistent or already in use elsewhere...create and add a new one!
+                    if (cell != null && cell.getItemView().getParent() == CutoutViewIndicator.this) {
+                        Log.w(TAG, "It would appear that the view at " + i + " was not removed properly.");
+                    }
+
+                    cell = createCellFor(i);
+                    cells.put(i, cell);
+                }
+
+                // This will invalidate the added view, triggering a call to this class's onMeasure()
+                addView(cell.getItemView(), i);
+            }
         }
 
         /**

--- a/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
+++ b/indicator/src/main/java/com/fuzz/indicator/CutoutViewIndicator.java
@@ -523,7 +523,15 @@ public class CutoutViewIndicator extends LinearLayout {
         showOffsetIndicator(position, new IndicatorOffsetEvent(position, percentageOffset, getOrientation()));
     }
 
-    public void showOffsetIndicator(int position, IndicatorOffsetEvent offsetEvent) {
+    /**
+     * Implementation-agnostic overload of {@link #showOffsetIndicator(int, float)}. Please
+     * refer to that method's javadoc (with its line drawing) to understand precisely what
+     * this method does.
+     *
+     * @param position       corresponds to the view where an indicator should be shown. Must be less than {@link #getChildCount()}
+     * @param offsetEvent    encapsulates offset and orientation information.
+     */
+    public void showOffsetIndicator(int position, @NonNull IndicatorOffsetEvent offsetEvent) {
         CutoutCell child = getCutoutCellAt(position);
         // We have something to draw
         if (child != null) {

--- a/indicator/src/main/java/com/fuzz/indicator/IndicatorOffsetEvent.java
+++ b/indicator/src/main/java/com/fuzz/indicator/IndicatorOffsetEvent.java
@@ -29,6 +29,9 @@ public class IndicatorOffsetEvent implements OffsetEvent {
 
     protected final int orientation;
 
+    @OffSetFlag
+    protected int offSetFlags = OffSetFlag.IMAGE_TRANSLATE;
+
     public IndicatorOffsetEvent(int position, float fraction, int orientation) {
         this.position = position;
         this.fraction = fraction;
@@ -55,5 +58,28 @@ public class IndicatorOffsetEvent implements OffsetEvent {
      */
     public int getOrientation() {
         return orientation;
+    }
+
+    /**
+     * Call this to change the {@link #offSetFlags} attached to
+     * this event.
+     *
+     * @param offSetFlags    a bitwise OR of a couple
+     *                       {@link OffSetFlag} constants
+     * @see #getOffSetFlags()
+     */
+    public void setOffSetFlags(@OffSetFlag int offSetFlags) {
+        this.offSetFlags = offSetFlags;
+    }
+
+    /**
+     * If no flags were set manually, this defaults to {@link OffSetFlag#IMAGE_TRANSLATE}.
+     *
+     * @return the {@link OffSetFlag OffSetFlags} previously set on this IndicatorOffsetEvent.
+     * @see #setOffSetFlags(int)
+     */
+    @OffSetFlag
+    public int getOffSetFlags() {
+        return offSetFlags;
     }
 }

--- a/indicator/src/main/java/com/fuzz/indicator/IndicatorOffsetEvent.java
+++ b/indicator/src/main/java/com/fuzz/indicator/IndicatorOffsetEvent.java
@@ -29,8 +29,8 @@ public class IndicatorOffsetEvent implements OffsetEvent {
 
     protected final int orientation;
 
-    @OffSetFlag
-    protected int offSetFlags = OffSetFlag.IMAGE_TRANSLATE;
+    @OffSetHint
+    protected int offSetHints = OffSetHint.IMAGE_TRANSLATE;
 
     public IndicatorOffsetEvent(int position, float fraction, int orientation) {
         this.position = position;
@@ -61,25 +61,25 @@ public class IndicatorOffsetEvent implements OffsetEvent {
     }
 
     /**
-     * Call this to change the {@link #offSetFlags} attached to
+     * Call this to change the {@link #offSetHints} attached to
      * this event.
      *
-     * @param offSetFlags    a bitwise OR of a couple
-     *                       {@link OffSetFlag} constants
-     * @see #getOffSetFlags()
+     * @param offSetHints    a bitwise OR of a couple
+     *                       {@link OffSetHint} constants
+     * @see #getOffSetHints()
      */
-    public void setOffSetFlags(@OffSetFlag int offSetFlags) {
-        this.offSetFlags = offSetFlags;
+    public void setOffSetHints(@OffSetHint int offSetHints) {
+        this.offSetHints = offSetHints;
     }
 
     /**
-     * If no flags were set manually, this defaults to {@link OffSetFlag#IMAGE_TRANSLATE}.
+     * If no hints were set manually, this defaults to {@link OffSetHint#IMAGE_TRANSLATE}.
      *
-     * @return the {@link OffSetFlag OffSetFlags} previously set on this IndicatorOffsetEvent.
-     * @see #setOffSetFlags(int)
+     * @return the {@link OffSetHint OffSetHints} previously set on this IndicatorOffsetEvent.
+     * @see #setOffSetHints(int)
      */
-    @OffSetFlag
-    public int getOffSetFlags() {
-        return offSetFlags;
+    @OffSetHint
+    public int getOffSetHints() {
+        return offSetHints;
     }
 }

--- a/indicator/src/main/java/com/fuzz/indicator/OffSetFlag.java
+++ b/indicator/src/main/java/com/fuzz/indicator/OffSetFlag.java
@@ -1,0 +1,48 @@
+package com.fuzz.indicator;
+
+import android.graphics.Matrix;
+import android.support.annotation.IntDef;
+import android.view.View;
+import android.widget.ImageView;
+
+import static com.fuzz.indicator.OffSetFlag.ALPHA;
+import static com.fuzz.indicator.OffSetFlag.IMAGE_ALPHA;
+import static com.fuzz.indicator.OffSetFlag.IMAGE_SCALE;
+import static com.fuzz.indicator.OffSetFlag.SCALE;
+import static com.fuzz.indicator.OffSetFlag.IMAGE_TRANSLATE;
+
+/**
+ * @author Philip Cohn-Cort (Fuzz)
+ */
+@IntDef(value =
+        {IMAGE_TRANSLATE,
+                ALPHA, IMAGE_ALPHA,
+                SCALE, IMAGE_SCALE
+        },
+        flag = true)
+public @interface OffSetFlag {
+    /**
+     * Corresponds to {@link OffSetters#offsetImageBy(ImageView, int, float, Matrix)}
+     */
+    int IMAGE_TRANSLATE = 1;
+    /**
+     * Corresponds to {@link OffSetters#offsetAlphaBy(View, float)}
+     * @see #IMAGE_ALPHA
+     */
+    int ALPHA               = 1 << 1;
+    /**
+     * Corresponds to {@link OffSetters#offsetImageAlphaBy(ImageView, float)}
+     * @see #ALPHA
+     */
+    int IMAGE_ALPHA         = 1 << 2;
+    /**
+     * Corresponds to {@link OffSetters#offsetScaleBy(View, float)}
+     * @see #IMAGE_SCALE
+     */
+    int SCALE               = 1 << 3;
+    /**
+     * Corresponds to {@link OffSetters#offsetImageScaleBy(ImageView, float)}
+     * @see #SCALE
+     */
+    int IMAGE_SCALE         = 1 << 4;
+}

--- a/indicator/src/main/java/com/fuzz/indicator/OffSetHint.java
+++ b/indicator/src/main/java/com/fuzz/indicator/OffSetHint.java
@@ -5,11 +5,11 @@ import android.support.annotation.IntDef;
 import android.view.View;
 import android.widget.ImageView;
 
-import static com.fuzz.indicator.OffSetFlag.ALPHA;
-import static com.fuzz.indicator.OffSetFlag.IMAGE_ALPHA;
-import static com.fuzz.indicator.OffSetFlag.IMAGE_SCALE;
-import static com.fuzz.indicator.OffSetFlag.SCALE;
-import static com.fuzz.indicator.OffSetFlag.IMAGE_TRANSLATE;
+import static com.fuzz.indicator.OffSetHint.ALPHA;
+import static com.fuzz.indicator.OffSetHint.IMAGE_ALPHA;
+import static com.fuzz.indicator.OffSetHint.IMAGE_SCALE;
+import static com.fuzz.indicator.OffSetHint.SCALE;
+import static com.fuzz.indicator.OffSetHint.IMAGE_TRANSLATE;
 
 /**
  * @author Philip Cohn-Cort (Fuzz)
@@ -20,7 +20,7 @@ import static com.fuzz.indicator.OffSetFlag.IMAGE_TRANSLATE;
                 SCALE, IMAGE_SCALE
         },
         flag = true)
-public @interface OffSetFlag {
+public @interface OffSetHint {
     /**
      * Corresponds to {@link OffSetters#offsetImageBy(ImageView, int, float, Matrix)}
      */

--- a/indicator/src/main/java/com/fuzz/indicator/OffSetters.java
+++ b/indicator/src/main/java/com/fuzz/indicator/OffSetters.java
@@ -16,14 +16,19 @@
 package com.fuzz.indicator;
 
 import android.graphics.Matrix;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.Spannable;
+import android.util.Property;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.fuzz.indicator.style.MigratoryRange;
 import com.fuzz.indicator.style.MigratorySpan;
+
+import static android.os.Build.VERSION_CODES.KITKAT;
 
 /**
  * Collection of utility methods for offsetting specific views.
@@ -36,6 +41,25 @@ import com.fuzz.indicator.style.MigratorySpan;
  * @author Philip Cohn-Cort (Fuzz)
  */
 public class OffSetters {
+
+    /**
+     * The standard {@link View#setAlpha(float)} method will override any user-provided
+     * alpha values. The TransitionAlpha, however, does not have any side effects and
+     * will peacefully coexist with standard alpha transparency.
+     * <p>
+     *     If the device is running KITKAT or higher, this TransitionAlpha will be used.
+     * </p>
+     */
+    protected static final Property<View, Float> setAlpha;
+
+    static {
+        if (Build.VERSION.SDK_INT >= KITKAT) {
+            setAlpha = Property.of(View.class, float.class, "transitionAlpha");
+        } else {
+            setAlpha = View.ALPHA;
+        }
+    }
+
     /**
      * Sets a new image matrix on this view. This method only allows orthogonal offsets
      *
@@ -54,8 +78,28 @@ public class OffSetters {
             offsetX = percentage * imageView.getWidth();
             offsetY = 0;
         }
-        mat.setTranslate(offsetX, offsetY);
+        mat.preTranslate(offsetX, offsetY);
         imageView.setImageMatrix(mat);
+    }
+
+    public static void offsetImageAlphaBy(@NonNull ImageView imageView, float fraction) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            imageView.setImageAlpha((int) (fraction * 255));
+        }
+    }
+
+    public static void offsetAlphaBy(@NonNull View imageView, float fraction) {
+        setAlpha.set(imageView, fraction);
+    }
+
+    public static void offsetImageScaleBy(@NonNull ImageView imageView, float fraction) {
+        Matrix matrix = new Matrix(imageView.getImageMatrix());
+        matrix.preScale(fraction, fraction);
+    }
+
+    public static void offsetScaleBy(@NonNull View imageView, float fraction) {
+        imageView.setScaleX(fraction);
+        imageView.setScaleY(fraction);
     }
 
     /**

--- a/indicator/src/main/java/com/fuzz/indicator/clip/FrameAwareCutoutImageCell.java
+++ b/indicator/src/main/java/com/fuzz/indicator/clip/FrameAwareCutoutImageCell.java
@@ -72,7 +72,7 @@ public class FrameAwareCutoutImageCell extends CutoutImageCell {
     @Nullable
     protected Drawable chooseDrawable(@NonNull CutoutViewLayoutParams lp) {
         Drawable chosen;
-        if (frames == null || lp.position <= -1 || latestResourceId != lp.indicatorDrawableId) {
+        if (lp.position <= -1 || latestResourceId != lp.indicatorDrawableId) {
             latestResourceId = lp.indicatorDrawableId;
             chosen = ContextCompat.getDrawable(itemView.getContext(), lp.indicatorDrawableId);
             if (chosen instanceof AnimationDrawable) {

--- a/indicator/src/test/java/com/fuzz/indicator/OffsetImageViewTest.java
+++ b/indicator/src/test/java/com/fuzz/indicator/OffsetImageViewTest.java
@@ -84,7 +84,7 @@ public class OffsetImageViewTest {
         OffSetters.offsetImageBy(imageView, orientation, fraction, matrix);
 
         // How do we test the method is setting the right values without copying its logic to here?
-        verify(matrix).setTranslate(anyFloat(), anyFloat());
+        verify(matrix).preTranslate(anyFloat(), anyFloat());
         verify(imageView).setImageMatrix(matrix);
     }
 


### PR DESCRIPTION
For issue #51 we basically just needed a few new methods in `OffSetters` and a field in `IndicatorOffsetEvent`. This PR includes some modifications to `CutoutImageCell` so that more than one transformation can be performed at the same time on the same `IndicatorOffsetEvent`.