### PR TITLE
Issue #79: Update Gradle dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ android:
     - platform-tools
 
     # Please try to keep these versions in sync with build.gradle
-    - platform-tools-25.0.2
+    - platform-tools-29.0.4
     - build-tools-28.0.3
 
     # Need to include a platform for android.compileSdkVersion
-    - android-25
+    - android-27
     # Plus one for the emulator
     - android-21
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ android:
 
     # Please try to keep these versions in sync with build.gradle
     - platform-tools-25.0.2
-    - build-tools-25.0.2
+    - build-tools-28.0.3
 
     # Need to include a platform for android.compileSdkVersion
     - android-25

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 * Depend on ClippedImageView: v0.1.0 ([#79])
 * Updated gradle: 3.2.1 -> 5.6.2 ([#76], [#79])
 * Updated AGP: 2.3.2 -> 3.5.1 ([#79])
+* Target Android SDK 27 (Oreo MR1) ([#79])
 
 # [0.8.2]
 ## Fix crashes

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 
 ### Library changes:
 * Files removed: ClippedImageView, UnDrawable, etc. in own artifact ([#76])
+* Wear project has been updated to build against the 2.5.0 release
+* Depend on ClippedImageView: v0.1.0 ([#79])
+* Updated gradle: 3.2.1 -> 5.6.2 ([#76], [#79])
+* Updated AGP: 2.3.2 -> 3.5.1 ([#79])
 
 # [0.8.2]
 ## Fix crashes
@@ -160,3 +164,4 @@
 [#71]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/71
 [#73]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/73
 [#76]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/76
+[#79]: https://github.com/fuzz-productions/CutoutViewIndicator/issues/79

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 ### Library changes:
 * Files removed: ClippedImageView, UnDrawable, etc. in own artifact ([#76])
 * Wear project has been updated to build against the 2.5.0 release
-* Depend on ClippedImageView: v0.1.0 ([#79])
+* Depend on ClippedImageView: v0.2.0 ([#79])
 * Updated gradle: 3.2.1 -> 5.6.2 ([#76], [#79])
 * Updated AGP: 2.3.2 -> 3.5.1 ([#79])
 * Target Android SDK 27 (Oreo MR1) ([#79])

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
 
         // Enable deployment of the library via maven
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
@@ -33,6 +34,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url "https://jitpack.io" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,7 @@ allprojects {
          * targetVersion equals the most recent stable, released SDK version. The sources
          * for that version must be open to the public.
          */
-        targetVersion = 25
-        /**
-         * buildVersion references the latest version of the android build tools that is both
-         * stable and compatible with $targetVersion
-         */
-        buildVersion = '25.0.2'
+        targetVersion = 27
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 08 22:42:50 EDT 2017
+#Mon Oct 14 18:29:56 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/indicator/build.gradle
+++ b/indicator/build.gradle
@@ -38,7 +38,6 @@ configurations {
 
 android {
     compileSdkVersion project.ext.targetVersion
-    buildToolsVersion project.ext.buildVersion
 
     defaultConfig {
         minSdkVersion 14

--- a/indicator/build.gradle
+++ b/indicator/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ apply plugin: 'com.github.dcendents.android-maven'
  * supportVersion is the oldest version of the support libraries against which this
  * codebase can compile.
  */
-def supportVersion = '22.2.0'
+def supportVersion = '27.1.1'
 
 // Maven deployment info (the name of the artifact is derived from the containing folder's name)
 group = 'com.fuzz'
@@ -67,13 +67,13 @@ dependencies {
     })
 
     // Starting with support lib 24.2.0, ViewPager should be included with the following directive
-    //api "com.android.support:support-core-ui:$supportVersion"
+    //noinspection GradleDependency
+    api "com.android.support:support-core-ui:$supportVersion"
 
     // Before that, though, this is the best way to include a ViewPager dependency.
-    //noinspection GradleDependency
-    api "com.android.support:support-v4:$supportVersion"
+    //api "com.android.support:support-v4:$supportVersion"
 
-    api "com.github.fuzz-productions:ClippedImageView:v0.1.0"
+    api 'com.github.fuzz-productions:ClippedImageView:v0.2.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:2.2.5"

--- a/indicator/build.gradle
+++ b/indicator/build.gradle
@@ -67,16 +67,16 @@ dependencies {
     })
 
     // Starting with support lib 24.2.0, ViewPager should be included with the following directive
-    //compile "com.android.support:support-core-ui:$supportVersion"
+    //api "com.android.support:support-core-ui:$supportVersion"
 
     // Before that, though, this is the best way to include a ViewPager dependency.
     //noinspection GradleDependency
-    compile "com.android.support:support-v4:$supportVersion"
+    api "com.android.support:support-v4:$supportVersion"
 
-    compile "com.github.fuzz-productions:ClippedImageView:v0.1.0"
+    api "com.github.fuzz-productions:ClippedImageView:v0.1.0"
 
-    testCompile 'junit:junit:4.12'
-    testCompile "org.mockito:mockito-core:2.2.5"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.mockito:mockito-core:2.2.5"
 
     // Manually include the classes jars - javadoc can't be directly built from aars at this time
     javadocDeps fileTree(dir: "$project.buildDir/intermediates/exploded-aar/", include:"**/classes.jar")

--- a/indicator/build.gradle
+++ b/indicator/build.gradle
@@ -104,13 +104,13 @@ task javadoc(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 
 // A proper sources jar, with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/indicator/src/main/java/com/fuzz/indicator/LayoutLogger.java
+++ b/indicator/src/main/java/com/fuzz/indicator/LayoutLogger.java
@@ -1,14 +1,9 @@
 package com.fuzz.indicator;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.support.annotation.NonNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.KITKAT;
 
 /**
  * Accessible variant of
@@ -64,13 +59,13 @@ public class LayoutLogger {
         protected Object layoutLog;
         protected Method warning;
 
-        @TargetApi(Build.VERSION_CODES.KITKAT)
         public void logToLayoutLib(String tag, String message) {
-            if (SDK_INT >= KITKAT) {
-                try {
-                    getWarningMethod().invoke(getLayoutLog(), tag, message, null);
-                } catch (ReflectiveOperationException ignore) {
-                }
+            try {
+                getWarningMethod().invoke(getLayoutLog(), tag, message, null);
+            } catch (InvocationTargetException ignored) {
+            } catch (IllegalAccessException ignored) {
+            } catch (NoSuchMethodException ignored) {
+            } catch (ClassNotFoundException ignored) {
             }
         }
 

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -19,13 +19,12 @@ apply plugin: 'com.android.application'
 // For reference: project.ext variables are defined in the top-level build.gradle file
 /**
  * supportVersion denotes the most recent stable version of the support libraries
- * compatible with project.ext.targetVersion and project.ext.buildVersion
+ * compatible with project.ext.targetVersion
  */
 def supportVersion = "25.2.0"
 
 android {
     compileSdkVersion project.ext.targetVersion
-    buildToolsVersion project.ext.buildVersion
     defaultConfig {
         applicationId "com.fuzz.emptyhusk"
         minSdkVersion 15

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
  * supportVersion denotes the most recent stable version of the support libraries
  * compatible with project.ext.targetVersion
  */
-def supportVersion = "25.2.0"
+def supportVersion = "27.1.1"
 
 android {
     compileSdkVersion project.ext.targetVersion

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -48,19 +48,19 @@ android {
 
 dependencies {
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     wearApp project(':wear')
-    //compile 'com.google.android.gms:play-services:9.2.0'
+    //implementation 'com.google.android.gms:play-services:9.2.0'
 
-    compile project(":indicator")
+    implementation project(":indicator")
     //noinspection GradleDependency (distracting false positives)
-    compile "com.android.support:appcompat-v7:$supportVersion"
+    implementation "com.android.support:appcompat-v7:$supportVersion"
     //noinspection GradleDependency (distracting false positives)
-    compile "com.android.support:design:$supportVersion"
+    implementation "com.android.support:design:$supportVersion"
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 if (project.hasProperty('waitForEmulator')) {

--- a/mobile/src/main/java/com/fuzz/emptyhusk/prefab/NarrowerSegmentsFragment.java
+++ b/mobile/src/main/java/com/fuzz/emptyhusk/prefab/NarrowerSegmentsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,13 @@ public class NarrowerSegmentsFragment extends Fragment {
             final CutoutViewIndicator cvi = (CutoutViewIndicator) view.findViewById(R.id.cutoutViewIndicator);
             initIndicator(recyclerView, cvi);
 
-            cvi.setGenerator(new ProportionalImageCellGenerator());
+            // We want the RecyclerView to be fully laid out by the time ::setGenerator is called
+            cvi.post(new Runnable() {
+                @Override
+                public void run() {
+                    cvi.setGenerator(new ProportionalImageCellGenerator());
+                }
+            });
         }
     }
 

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -19,13 +19,12 @@ apply plugin: 'com.android.application'
 // For reference: project.ext variables are defined in the top-level build.gradle file
 /**
  * supportVersion denotes the most recent stable version of the support libraries
- * compatible with project.ext.targetVersion and project.ext.buildVersion
+ * compatible with project.ext.targetVersion
  */
 def supportVersion = "24.2.1"
 
 android {
     compileSdkVersion project.ext.targetVersion
-    buildToolsVersion project.ext.buildVersion
     defaultConfig {
         applicationId "com.fuzz.emptyhusk"
         minSdkVersion 21

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
  * supportVersion denotes the most recent stable version of the support libraries
  * compatible with project.ext.targetVersion
  */
-def supportVersion = "24.2.1"
+def supportVersion = "27.1.1"
 
 android {
     compileSdkVersion project.ext.targetVersion

--- a/tv/build.gradle
+++ b/tv/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:recyclerview-v7:$supportVersion"
-    compile "com.android.support:leanback-v17:$supportVersion"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:recyclerview-v7:$supportVersion"
+    implementation "com.android.support:leanback-v17:$supportVersion"
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.ext.targetVersion
-    buildToolsVersion project.ext.buildVersion
     defaultConfig {
         applicationId "com.fuzz.emptyhusk"
         minSdkVersion 21

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -38,6 +38,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:2.0.0'
-    provided 'com.google.android.wearable:wearable:2.0.0'
+    compile 'com.google.android.support:wearable:2.5.0'
+    provided 'com.google.android.wearable:wearable:2.5.0'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:2.5.0'
-    provided 'com.google.android.wearable:wearable:2.5.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.google.android.support:wearable:2.5.0'
+    compileOnly 'com.google.android.wearable:wearable:2.5.0'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Philip Cohn-Cort
+ * Copyright 2016-2019 Philip Cohn-Cort
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As hinted at by issue #79, we are a little behind the times. This PR updates the following to reflect modern sensibilities:

* Android Gradle Plugin (2.3.2 -> 3.5.1)
* Gradle + Gradle Wrapper (4.1rc1 -> 5.6.2)
* Wearable Support libraries (2.0.0 -> 2.5.0)
* Build Tools Version (25.0.2 -> 28.0.3)